### PR TITLE
feat(content): trust pages, nav CTA, footer legal, FAQ schema, 404, microcopy (cd-004/005/006)

### DIFF
--- a/.gsd/package-lock.json
+++ b/.gsd/package-lock.json
@@ -2134,6 +2134,84 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
@@ -2239,84 +2317,6 @@
           "optional": true
         },
         "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
           "optional": true
         }
       }

--- a/.gsd/sdk/package-lock.json
+++ b/.gsd/sdk/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@gsd-build/sdk",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
         "ws": "^8.20.0"
@@ -1775,9 +1776,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/wp-content/mu-plugins/gano-seo.php
+++ b/wp-content/mu-plugins/gano-seo.php
@@ -491,6 +491,11 @@ function gano_og_fallback(): void {
     echo '<meta property="og:description" content="' . esc_attr( $description ) . '">' . "\n";
     echo '<meta property="og:url"         content="' . esc_url( $url )          . '">' . "\n";
     echo '<meta property="og:image"       content="' . esc_url( $image )        . '">' . "\n";
+    // Dimensiones declaradas — evita warnings en Facebook Sharing Debugger y Twitter Card Validator
+    // Spec: memory/content/social-preview-spec-wave3.md §6 (cd-content-006)
+    echo '<meta property="og:image:width"  content="1200">' . "\n";
+    echo '<meta property="og:image:height" content="630">'  . "\n";
+    echo '<meta property="og:image:type"   content="image/webp">' . "\n";
     echo '<meta property="og:site_name"   content="' . esc_attr( $site_name )   . '">' . "\n";
     echo '<meta property="og:locale"      content="es_CO">' . "\n";
     echo '<meta name="twitter:card"       content="summary_large_image">' . "\n";

--- a/wp-content/themes/gano-child/404.php
+++ b/wp-content/themes/gano-child/404.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * 404 — Página no encontrada
+ * Microcopy: memory/content/microcopy-wave3-kit.md §4e
+ *
+ * @package gano-child
+ */
+get_header();
+?>
+
+<main id="gano-main-content" class="gano-trust-page gano-404">
+
+  <section class="gano-dark-section" style="min-height: 60vh; display: flex; align-items: center; text-align: center;">
+    <div class="gano-container" style="width: 100%;">
+
+      <p class="gano-label-pill" aria-hidden="true">404</p>
+      <h1 style="font-size: var(--gano-fs-4xl, 2.25rem); font-weight: 700; line-height: 1.1; max-width: 640px; margin: .75rem auto 1rem;">
+        Esta página no existe (todavía)
+      </h1>
+      <p style="color: rgba(255,255,255,.75); max-width: 520px; margin: 0 auto 2rem; line-height: 1.65;">
+        El enlace puede estar desactualizado o la página fue movida.
+        No se ha perdido nada importante: desde aquí puedes ir a donde necesitas.
+      </p>
+
+      <div style="display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center;">
+        <a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="gano-btn">
+          Ir al inicio
+        </a>
+        <a href="<?php echo esc_url( home_url( '/ecosistemas' ) ); ?>"
+           style="color: #fff; text-decoration: underline; align-self: center; font-weight: 500;">
+          Ver planes →
+        </a>
+      </div>
+
+      <p style="margin-top: 2rem; font-size: .875rem; color: rgba(255,255,255,.5);">
+        ¿Crees que esto es un error?
+        <a href="<?php echo esc_url( home_url( '/contacto' ) ); ?>"
+           style="color: rgba(255,255,255,.75); text-decoration: underline;">
+          Escríbenos
+        </a>.
+      </p>
+
+    </div>
+  </section>
+
+</main>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -836,6 +836,38 @@ function gano_get_sota_categories(): array {
 	];
 }
 
+// =============================================================================
+// CD-CONTENT-006 — WOOCOMMERCE MICROCOPY (carrito vacío)
+//   Referencia: memory/content/microcopy-wave3-kit.md §4a
+// =============================================================================
+
+/**
+ * Reemplaza el mensaje de carrito vacío de WooCommerce con copy de marca.
+ * Pronombre: tú (contexto marketing). role="status" para lectores de pantalla.
+ */
+add_filter( 'woocommerce_empty_cart_message', 'gano_child_empty_cart_message' );
+function gano_child_empty_cart_message(): string {
+    ob_start();
+    ?>
+    <div class="gano-empty-cart" role="status">
+      <p><strong>Tu carrito está vacío</strong></p>
+      <p>Aún no has agregado ningún ecosistema a tu pedido.</p>
+      <p style="color:#64748b; font-size:.9rem; margin-bottom:1.25rem;">
+        ¿No sabes por dónde empezar? Compara los ecosistemas o cuéntanos sobre tu sitio y te orientamos.
+      </p>
+      <a href="<?php echo esc_url( home_url( '/ecosistemas' ) ); ?>" class="gano-btn">
+        Ver arquitecturas y planes
+      </a>
+      &ensp;
+      <a href="<?php echo esc_url( home_url( '/contacto' ) ); ?>"
+         style="font-weight:600; color:var(--gano-blue,#2952CC);">
+        Hablar con el equipo
+      </a>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}
+
 /**
  * Retrieves all SOTA hub pages ordered by menu order then date.
  * Returns published and draft pages so the hub can show "En Preparación" cards.

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -874,6 +874,98 @@ function gano_child_empty_cart_message(): string {
  *
  * @return WP_Post[]
  */
+// =============================================================================
+// CD-CONTENT-005 — FAQ SCHEMA (preguntas adicionales aprobadas para homepage)
+// =============================================================================
+
+/**
+ * Agrega preguntas FAQ adicionales al schema JSON-LD de la homepage.
+ *
+ * Las preguntas pendientes de datos reales (SLA backups, NIT, SLA soporte)
+ * están en memory/content/faq-schema-candidates-wave3.md como candidatos C01–C10.
+ * Solo se activan aquí las que no dependen de placeholders.
+ *
+ * Para agregar más preguntas una vez Diego confirme los datos reales:
+ *   $questions[] = array( 'question' => '¿…?', 'answer' => '…' );
+ */
+add_filter( 'gano_faq_questions', 'gano_child_faq_extra_questions' );
+function gano_child_faq_extra_questions( array $questions ): array {
+
+    // C04 — ¿Necesito conocimientos técnicos? (sin placeholders)
+    $questions[] = array(
+        'question' => '¿Necesito saber programación o administración de servidores para gestionar mi plan?',
+        'answer'   => 'No. Los ecosistemas de Gano Digital están diseñados para que puedas operar tu WordPress sin tocar el servidor. El panel de control es visual, la configuración inicial la hacemos contigo y el monitoreo proactivo actúa antes de que notes un problema.',
+    );
+
+    // C07 — Escalabilidad: cambiar de ecosistema (sin placeholders)
+    $questions[] = array(
+        'question' => '¿Puedo cambiar de ecosistema si mi negocio crece?',
+        'answer'   => 'Sí. El camino natural es Núcleo Prime → Fortaleza Delta → Bastión SOTA. El cambio de ecosistema se coordina con el equipo de Gano Digital; migramos los recursos sin afectar la disponibilidad de tu sitio. No hay penalización por escalar.',
+    );
+
+    // C09 — Diferencia Núcleo Prime vs Bastión SOTA (sin placeholders de precio)
+    $questions[] = array(
+        'question' => '¿Cuál es la diferencia principal entre el ecosistema Núcleo Prime y Bastión SOTA?',
+        'answer'   => 'Núcleo Prime es la base de alto rendimiento: almacenamiento NVMe, WordPress optimizado y seguridad esencial, ideal para negocios en crecimiento. Bastión SOTA es la capa de resiliencia total: redundancia activa, respaldos con mayor frecuencia, soporte prioritario y monitoreo avanzado, pensado para operaciones críticas que no pueden tolerar interrupciones.',
+    );
+
+    // C10 — WordPress como plataforma (sin placeholders)
+    $questions[] = array(
+        'question' => '¿Por qué construir sobre WordPress en lugar de otra plataforma?',
+        'answer'   => 'WordPress impulsa más del 43 % de la web mundial, cuenta con el ecosistema de plugins y temas más grande del mercado, y ofrece control total sobre tu contenido y datos. Gano Digital especializa su infraestructura exclusivamente en WordPress para llevar esa plataforma a niveles enterprise: optimizaciones a nivel de servidor, caching inteligente y hardening específico que una solución genérica no puede ofrecer.',
+    );
+
+    return $questions;
+}
+
+// =============================================================================
+// CD-CONTENT-005 — FOOTER LEGAL: shortcode + acción wp_footer
+// =============================================================================
+
+/**
+ * Shortcode [gano_footer_legal] para usar en Elementor HTML widget o footer template.
+ *
+ * Uso en Elementor: widget HTML → [gano_footer_legal]
+ * Uso en PHP: echo do_shortcode('[gano_footer_legal]');
+ *
+ * @return string HTML del footer legal.
+ */
+add_shortcode( 'gano_footer_legal', 'gano_child_footer_legal_shortcode' );
+function gano_child_footer_legal_shortcode(): string {
+    $legal_links = array(
+        array( 'label' => 'Términos y Condiciones', 'url' => '/legal/terminos-y-condiciones' ),
+        array( 'label' => 'Política de Privacidad',  'url' => '/legal/politica-de-privacidad'  ),
+        array( 'label' => 'SLA',                     'url' => '/legal/acuerdo-de-nivel-de-servicio' ),
+        array( 'label' => 'Hosting WordPress Colombia', 'url' => '/hosting-wordpress-colombia' ),
+    );
+
+    $year     = gmdate( 'Y' );
+    $site_url = get_site_url();
+
+    ob_start();
+    ?>
+    <div class="gano-footer-legal">
+      <nav aria-label="<?php esc_attr_e( 'Menú legal', 'gano-child' ); ?>">
+        <ul class="gano-footer-legal__nav">
+          <?php foreach ( $legal_links as $link ) : ?>
+            <li>
+              <a href="<?php echo esc_url( $site_url . $link['url'] ); ?>">
+                <?php echo esc_html( $link['label'] ); ?>
+              </a>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      </nav>
+      <p class="gano-footer-legal__copy">
+        &copy; <?php echo esc_html( $year ); ?>
+        <a href="<?php echo esc_url( $site_url ); ?>">Gano Digital</a>.
+        Hosting WordPress en Colombia — operado sobre infraestructura GoDaddy Reseller.
+      </p>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}
+
 function gano_get_sota_hub_pages(): array {
 	$args = [
 		'post_type'      => 'page',

--- a/wp-content/themes/gano-child/style.css
+++ b/wp-content/themes/gano-child/style.css
@@ -1535,6 +1535,95 @@ select:focus-visible {
     pointer-events: none;
 }
 
+/* =============================================================================
+   NAVEGACIÓN — CTA "Elegir plan →" en header (cd-content-005)
+   Aplica cuando el ítem de menú tiene la CSS class "gano-menu-cta" en wp-admin.
+   ============================================================================= */
+
+.gano-menu-cta > a,
+.gano-menu-cta > a:visited {
+    background: var(--gano-orange, #E85D04);
+    color: #fff !important;
+    padding: 0.5rem 1.25rem;
+    border-radius: 4px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    text-decoration: none !important;
+    transition: opacity 0.2s ease, background 0.2s ease;
+    display: inline-block;
+}
+
+.gano-menu-cta > a:hover,
+.gano-menu-cta > a:focus {
+    opacity: 0.88;
+    background: var(--gano-orange, #E85D04);
+}
+
+.gano-menu-cta > a:focus-visible {
+    outline: 3px solid var(--gano-gold, #D4AF37);
+    outline-offset: 3px;
+}
+
+/* Separador visual antes del ítem "Comparar todos" en el dropdown de Ecosistemas */
+.menu-separator > a {
+    border-top: 1px solid #e2e8f0;
+    margin-top: 0.25rem;
+    padding-top: 0.75rem;
+}
+
+/* =============================================================================
+   FOOTER LEGAL — Barra inferior de trust (cd-content-005)
+   Generada por shortcode [gano_footer_legal] o wp_nav_menu location 'footer'.
+   ============================================================================= */
+
+.gano-footer-legal {
+    background: #0f172a;
+    color: #94a3b8;
+    padding: 1.5rem 1.5rem;
+    text-align: center;
+    font-size: 0.8125rem;
+    line-height: 1.75;
+}
+
+.gano-footer-legal__nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.25rem 1.25rem;
+    list-style: none;
+    margin: 0 0 0.75rem;
+    padding: 0;
+}
+
+.gano-footer-legal__nav li a {
+    color: #94a3b8;
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+
+.gano-footer-legal__nav li a:hover {
+    color: #e2e8f0;
+    text-decoration: underline;
+}
+
+.gano-footer-legal__copy {
+    margin: 0;
+    color: #64748b;
+}
+
+.gano-footer-legal__copy a {
+    color: #94a3b8;
+    text-decoration: none;
+}
+
+@media (max-width: 600px) {
+    .gano-footer-legal__nav {
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: center;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .gano-skip-link {
         transition: none;

--- a/wp-content/themes/gano-child/templates/page-contacto.php
+++ b/wp-content/themes/gano-child/templates/page-contacto.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Template Name: Contacto
+ * @package gano-child
+ */
+get_header(); ?>
+
+<main id="gano-main-content" class="gano-trust-page gano-contacto">
+
+  <section class="gano-dark-section gano-trust-hero">
+    <div class="gano-container">
+      <p class="gano-label-pill">Contacto</p>
+      <h1>Antes de comprar, habla con nosotros.</h1>
+      <p class="gano-trust-hero__sub">
+        Resolvemos dudas técnicas y comerciales sin presión de ventas.
+        El equipo responde en español, con contexto real de tu proyecto.
+      </p>
+    </div>
+  </section>
+
+  <section class="gano-trust-section">
+    <div class="gano-container gano-contacto__layout">
+
+      <!-- FORMULARIO -->
+      <div class="gano-contacto__form">
+        <h2>Escríbenos</h2>
+        <?php
+        // Si hay Contact Form 7 instalado, usa el shortcode aquí:
+        // echo do_shortcode('[contact-form-7 id="..." title="Contacto Gano"]');
+        // Por defecto, formulario HTML nativo con action al endpoint de WP:
+        ?>
+        <form method="post" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" class="gano-form">
+          <?php wp_nonce_field('gano_contacto_form', 'gano_contacto_nonce'); ?>
+          <input type="hidden" name="action" value="gano_contacto_submit">
+
+          <div class="gano-form__group">
+            <label for="gc-nombre">Nombre <span aria-hidden="true">*</span></label>
+            <input type="text" id="gc-nombre" name="nombre" required autocomplete="name"
+                   aria-required="true" placeholder="Tu nombre">
+          </div>
+
+          <div class="gano-form__group">
+            <label for="gc-empresa">Empresa <span class="gano-form__optional">(opcional)</span></label>
+            <input type="text" id="gc-empresa" name="empresa" autocomplete="organization"
+                   placeholder="Tu empresa o proyecto">
+          </div>
+
+          <div class="gano-form__group">
+            <label for="gc-email">Correo electrónico <span aria-hidden="true">*</span></label>
+            <input type="email" id="gc-email" name="email" required autocomplete="email"
+                   aria-required="true" placeholder="tu@correo.com">
+          </div>
+
+          <div class="gano-form__group">
+            <label for="gc-asunto">Asunto <span aria-hidden="true">*</span></label>
+            <select id="gc-asunto" name="asunto" required aria-required="true">
+              <option value="">Selecciona un asunto</option>
+              <option value="comercial">Quiero conocer los planes</option>
+              <option value="tecnico">Tengo una pregunta técnica</option>
+              <option value="soporte">Soporte a cliente existente</option>
+              <option value="otro">Otro</option>
+            </select>
+          </div>
+
+          <div class="gano-form__group">
+            <label for="gc-mensaje">Mensaje <span aria-hidden="true">*</span></label>
+            <textarea id="gc-mensaje" name="mensaje" required aria-required="true"
+                      rows="5" placeholder="Cuéntanos en qué podemos ayudarte"></textarea>
+          </div>
+
+          <p class="gano-form__privacy">
+            Al enviar este formulario aceptas nuestra
+            <a href="/legal/politica-de-privacidad">Política de Privacidad</a>.
+            No compartimos tu información con terceros.
+          </p>
+
+          <button type="submit" class="gano-btn">Enviar mensaje</button>
+        </form>
+      </div>
+
+      <!-- DATOS DE CONTACTO -->
+      <aside class="gano-contacto__info">
+        <h2>Datos de contacto</h2>
+
+        <div class="gano-contacto__item">
+          <strong>WhatsApp</strong>
+          <a href="https://wa.me/573135646123" target="_blank" rel="noopener">
+            +57 313 564 6123
+          </a>
+        </div>
+
+        <div class="gano-contacto__item">
+          <strong>Correo general</strong>
+          <a href="mailto:hola@gano.digital">hola@gano.digital</a>
+        </div>
+
+        <div class="gano-contacto__item">
+          <strong>Soporte técnico</strong>
+          <a href="mailto:soporte@gano.digital">soporte@gano.digital</a>
+        </div>
+
+        <div class="gano-contacto__item">
+          <strong>Asuntos legales</strong>
+          <a href="mailto:legal@gano.digital">legal@gano.digital</a>
+        </div>
+
+        <div class="gano-contacto__item">
+          <strong>Horario de atención</strong>
+          <span><!-- [NIT_PENDIENTE]: confirmar horario real antes de publicar -->
+            Por confirmar — soporte por ticket disponible 24/7
+          </span>
+        </div>
+
+        <hr style="margin:1.5rem 0; border-color:#e2e8f0;">
+
+        <p style="font-size:.875rem; color:#64748b;">
+          ¿Ya sabes qué necesitas?<br>
+          <a href="/ecosistemas">Ver planes y precios →</a>
+        </p>
+      </aside>
+
+    </div>
+  </section>
+
+</main>
+
+<style>
+.gano-contacto__layout { display: grid; grid-template-columns: 1fr 360px; gap: 3rem; align-items: start; }
+.gano-contacto__info { background: #f8fafc; border-radius: 12px; padding: 2rem; }
+.gano-contacto__item { margin-bottom: 1.25rem; }
+.gano-contacto__item strong { display: block; font-size: .75rem; text-transform: uppercase; letter-spacing: .06em; color: #64748b; margin-bottom: .25rem; }
+.gano-contacto__item a { color: var(--gano-blue, #2952CC); text-decoration: none; font-weight: 600; }
+.gano-contacto__item a:hover { text-decoration: underline; }
+.gano-form { display: flex; flex-direction: column; gap: 1.25rem; }
+.gano-form__group { display: flex; flex-direction: column; gap: .375rem; }
+.gano-form__group label { font-size: .875rem; font-weight: 600; }
+.gano-form__optional { font-weight: 400; color: #94a3b8; }
+.gano-form__group input,
+.gano-form__group select,
+.gano-form__group textarea { padding: .625rem .875rem; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 1rem; font-family: inherit; width: 100%; box-sizing: border-box; }
+.gano-form__group input:focus,
+.gano-form__group select:focus,
+.gano-form__group textarea:focus { outline: 3px solid var(--gano-blue, #2952CC); outline-offset: 2px; border-color: var(--gano-blue, #2952CC); }
+.gano-form__privacy { font-size: .8125rem; color: #64748b; margin: 0; }
+@media (max-width: 768px) { .gano-contacto__layout { grid-template-columns: 1fr; } }
+</style>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/gano-child/templates/page-nosotros.php
+++ b/wp-content/themes/gano-child/templates/page-nosotros.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Template Name: Nosotros — Quiénes somos
+ * @package gano-child
+ */
+get_header(); ?>
+
+<main id="gano-main-content" class="gano-trust-page gano-nosotros">
+
+  <!-- HERO -->
+  <section class="gano-dark-section gano-trust-hero">
+    <div class="gano-container">
+      <p class="gano-label-pill">Quiénes somos</p>
+      <h1>Hosting en serio. Sin rodeos.</h1>
+      <p class="gano-trust-hero__sub">
+        El mercado colombiano merece opciones de hosting que no requieran leer la letra pequeña tres veces para entender qué compraste.
+        Gano Digital existe para eso.
+      </p>
+    </div>
+  </section>
+
+  <!-- QUÉ HACEMOS -->
+  <section class="gano-trust-section">
+    <div class="gano-container gano-el-prose-narrow">
+      <h2>Ecosistemas WordPress de alto rendimiento para negocios en Colombia y LATAM.</h2>
+      <p>
+        No somos un datacenter. Somos el equipo que configura, protege y sostiene tu infraestructura.
+        Trabajamos con infraestructura de clase mundial —aprovisionada vía programa reseller de GoDaddy—
+        y le sumamos la capa que más duele cuando falta: configuración experta, hardening activo
+        y alguien al otro lado del chat que entiende WordPress y negocio en Colombia.
+      </p>
+      <p>
+        No prometemos lo que no podemos cumplir. Sí prometemos transparencia, respuesta
+        y un modelo de servicio que escala con tu empresa.
+      </p>
+    </div>
+  </section>
+
+  <!-- DIFERENCIADORES -->
+  <section class="gano-trust-section gano-trust-section--alt">
+    <div class="gano-container">
+      <h2>Lo que hacemos directamente</h2>
+      <div class="gano-trust-grid">
+        <?php
+        $diferenciadores = [
+          ['icon' => '🌐', 'titulo' => 'Español y COP',         'texto' => 'Soporte, contratos y facturación en tu idioma y moneda. Sin sorpresas de tipo de cambio.'],
+          ['icon' => '⚡', 'titulo' => 'WordPress con foco',    'texto' => 'No hacemos hosting genérico. Cada ecosistema está diseñado para cargas y flujos de WordPress.'],
+          ['icon' => '🛡',  'titulo' => 'Hardening incluido',   'texto' => 'Seguridad activa desde el día uno: CSP, Wordfence, rate limiting, backups monitoreados.'],
+          ['icon' => '🔍', 'titulo' => 'Monitoreo y respuesta', 'texto' => 'Visibilidad operativa real sobre tu instalación. Alertas antes del incidente, no después.'],
+          ['icon' => '📋', 'titulo' => 'Transparencia reseller','texto' => 'Decimos claramente quién provee la infraestructura y qué rol juega Gano Digital. Sin letra pequeña.'],
+          ['icon' => '🔑', 'titulo' => 'Soberanía del sitio',   'texto' => 'Tus credenciales, tu acceso, tu contenido. Migración asistida sin retención de datos.'],
+        ];
+        foreach ($diferenciadores as $d) : ?>
+          <article class="gano-el-pillar">
+            <span aria-hidden="true" style="font-size:1.75rem;"><?php echo $d['icon']; ?></span>
+            <h3><?php echo esc_html($d['titulo']); ?></h3>
+            <p><?php echo esc_html($d['texto']); ?></p>
+          </article>
+        <?php endforeach; ?>
+      </div>
+    </div>
+  </section>
+
+  <!-- TRANSPARENCIA RESELLER -->
+  <section class="gano-trust-section">
+    <div class="gano-container gano-el-prose-narrow">
+      <h2>Sobre nuestra infraestructura</h2>
+      <div class="gano-trust-disclaimer">
+        <p>
+          Gano Digital no opera un datacenter propio. Somos un operador de ecosistemas WordPress
+          que aprovisionamos capacidad de servidor a través del <strong>programa de reseller
+          autorizado de GoDaddy</strong>. Eso nos permite ofrecer infraestructura de nivel
+          empresarial —NVMe, CDN, redundancia, certificados SSL— sin el costo de construir
+          y mantener centros de datos.
+        </p>
+        <p>
+          La transparencia es parte del servicio. Si en algún momento tienes preguntas
+          sobre las condiciones de la infraestructura subyacente, te las respondemos con claridad.
+          Puedes consultar los términos de GoDaddy en
+          <a href="https://www.godaddy.com/es/legal" target="_blank" rel="noopener">godaddy.com/es/legal</a>.
+        </p>
+      </div>
+      <p style="margin-top:1.5rem;">
+        <a href="/legal/terminos-y-condiciones">Ver Términos y Condiciones</a>
+        &nbsp;·&nbsp;
+        <a href="/legal/acuerdo-de-nivel-de-servicio">Ver nuestro SLA</a>
+      </p>
+    </div>
+  </section>
+
+  <!-- EQUIPO -->
+  <section class="gano-trust-section gano-trust-section--alt">
+    <div class="gano-container gano-el-prose-narrow">
+      <h2>El equipo</h2>
+      <!-- [NIT_PENDIENTE]: Diego — añadir nombre, rol y bio real cuando esté disponible.
+           Omitir esta sección si no hay datos verificables; mejor no tener que tener stock. -->
+      <p style="color:#64748b; font-style:italic;">
+        Sección en preparación. Próximamente: el equipo detrás de Gano Digital.
+      </p>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="gano-dark-section" style="text-align:center; padding:4rem 1.5rem;">
+    <div class="gano-container">
+      <h2>¿Quieres saber qué arquitectura corresponde a tu etapa?</h2>
+      <p style="color:rgba(255,255,255,.75); margin-bottom:1.5rem;">Habla con el equipo. Sin formularios de ventas agresivos.</p>
+      <a href="/contacto" class="gano-btn">Habla con el equipo</a>
+      &nbsp;&nbsp;
+      <a href="/ecosistemas" style="color:#fff; text-decoration:underline;">Ver ecosistemas →</a>
+    </div>
+  </section>
+
+</main>
+
+<style>
+.gano-trust-hero { padding: 5rem 1.5rem 4rem; text-align: center; }
+.gano-trust-hero h1 { font-size: var(--gano-fs-4xl, 2.25rem); font-weight: 700; line-height: 1.1; max-width: 720px; margin: .75rem auto 1rem; }
+.gano-trust-hero__sub { color: rgba(255,255,255,.75); max-width: 600px; margin: 0 auto; line-height: 1.65; }
+.gano-trust-section { padding: 4rem 1.5rem; }
+.gano-trust-section--alt { background: #f8fafc; }
+.gano-trust-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1.25rem; margin-top: 2rem; }
+.gano-trust-disclaimer { background: #f1f5f9; border-left: 4px solid var(--gano-blue, #2952CC); padding: 1.25rem 1.5rem; border-radius: 0 8px 8px 0; line-height: 1.65; }
+.gano-trust-disclaimer p { margin: 0 0 .75rem; }
+.gano-trust-disclaimer p:last-child { margin: 0; }
+@media (max-width: 600px) { .gano-trust-grid { grid-template-columns: 1fr; } }
+</style>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/gano-child/templates/page-privacidad.php
+++ b/wp-content/themes/gano-child/templates/page-privacidad.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Template Name: Política de Privacidad
+ * @package gano-child
+ */
+get_header();
+$fecha_actualizacion = '2026-04-06';
+?>
+
+<main id="gano-main-content" class="gano-trust-page gano-legal">
+
+  <section class="gano-dark-section gano-trust-hero">
+    <div class="gano-container">
+      <p class="gano-label-pill">Legal</p>
+      <h1>Política de Privacidad</h1>
+      <p class="gano-trust-hero__sub">
+        Última actualización: <?php echo esc_html($fecha_actualizacion); ?>.
+        Ley 1581 de 2012 (Colombia) · GDPR aplicable.
+      </p>
+    </div>
+  </section>
+
+  <section class="gano-trust-section">
+    <div class="gano-container gano-el-prose-narrow gano-legal__body">
+
+      <section aria-labelledby="pp-responsable">
+        <h2 id="pp-responsable">1. Responsable del tratamiento</h2>
+        <ul>
+          <li><strong>Organización:</strong> Gano Digital <!-- [NIT_PENDIENTE]: razón social completa --></li>
+          <li><strong>NIT:</strong> [NIT_PENDIENTE]</li>
+          <li><strong>Domicilio:</strong> Colombia <!-- [NIT_PENDIENTE]: dirección fiscal --></li>
+          <li><strong>Correo de datos personales:</strong> <a href="mailto:legal@gano.digital">legal@gano.digital</a></li>
+          <li><strong>Teléfono / WhatsApp:</strong> <a href="https://wa.me/573135646123">+57 313 564 6123</a></li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="pp-datos">
+        <h2 id="pp-datos">2. Datos que se recopilan</h2>
+        <ul>
+          <li><strong>Datos de contacto:</strong> nombre, correo electrónico, empresa, teléfono (cuando el usuario los provee).</li>
+          <li><strong>Datos de navegación:</strong> dirección IP, tipo de navegador, páginas visitadas, duración de sesión (logs del servidor).</li>
+          <li><strong>Datos de pago:</strong> procesados directamente por el operador de checkout (GoDaddy Reseller). Gano Digital <strong>no almacena datos de tarjeta</strong>.</li>
+          <li><strong>Cookies técnicas:</strong> sesión y seguridad. Ver sección 6.</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="pp-finalidad">
+        <h2 id="pp-finalidad">3. Finalidad del tratamiento</h2>
+        <ul>
+          <li>Prestación del servicio contratado (hosting, soporte, facturación).</li>
+          <li>Respuesta a solicitudes de contacto y soporte técnico.</li>
+          <li>Mejora del sitio web y análisis de uso (datos agregados y anonimizados).</li>
+          <li>Cumplimiento de obligaciones legales (DIAN, SIC Colombia).</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="pp-base-legal">
+        <h2 id="pp-base-legal">4. Base legal del tratamiento</h2>
+        <ul>
+          <li><strong>Ejecución del contrato</strong> (Art. 6(1)(b) GDPR · Ley 1581/2012): para prestar los servicios contratados.</li>
+          <li><strong>Interés legítimo</strong>: análisis de uso del sitio (estadísticas anonimizadas).</li>
+          <li><strong>Cumplimiento de obligación legal</strong>: conservación de registros fiscales y contables.</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="pp-transferencias">
+        <h2 id="pp-transferencias">5. Transferencias internacionales</h2>
+        <p>
+          Los datos de alojamiento se procesan en infraestructura de GoDaddy, Inc. (Estados Unidos / Unión Europea).
+          Gano Digital informa al usuario de esta circunstancia al momento de contratar.
+          GoDaddy opera bajo las salvaguardas de transferencia internacional aplicables según normativa vigente.
+        </p>
+      </section>
+
+      <section aria-labelledby="pp-cookies">
+        <h2 id="pp-cookies">6. Cookies</h2>
+        <ul>
+          <li><strong>Cookies técnicas</strong> (sesión, seguridad): necesarias para el funcionamiento del sitio. No requieren consentimiento.</li>
+          <li><strong>Cookies analíticas</strong>: <!-- [NIT_PENDIENTE]: ¿se usa GA, Matomo u otra herramienta con tracking? Si es así, añadir banner de cookies con opt-in. Si no se usa analítica con tracking, indicarlo aquí. --></li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="pp-derechos">
+        <h2 id="pp-derechos">7. Derechos del titular</h2>
+        <p>El titular de los datos puede ejercer los siguientes derechos escribiendo a <a href="mailto:legal@gano.digital">legal@gano.digital</a>:</p>
+        <ul>
+          <li><strong>Acceso:</strong> conocer qué datos se tratan sobre usted.</li>
+          <li><strong>Rectificación:</strong> corregir datos inexactos o incompletos.</li>
+          <li><strong>Supresión:</strong> solicitar la eliminación de sus datos cuando proceda.</li>
+          <li><strong>Portabilidad:</strong> recibir sus datos en formato estructurado.</li>
+          <li><strong>Oposición:</strong> oponerse al tratamiento en determinadas circunstancias.</li>
+        </ul>
+        <p>Respondemos dentro de <!-- [NIT_PENDIENTE]: X días hábiles según normativa SIC --> los plazos establecidos por la Ley 1581 de 2012.</p>
+      </section>
+
+      <section aria-labelledby="pp-retencion">
+        <h2 id="pp-retencion">8. Retención de datos</h2>
+        <p>
+          Los datos se conservan durante la vigencia del contrato de servicio y,
+          posteriormente, por <!-- [NIT_PENDIENTE]: X años --> el tiempo exigido por la normativa
+          fiscal y contable colombiana aplicable.
+        </p>
+      </section>
+
+      <hr style="margin:2rem 0; border-color:#e2e8f0;">
+      <p class="gano-legal__footer-links">
+        <a href="/legal/terminos-y-condiciones">Términos y Condiciones</a>
+        &nbsp;·&nbsp;
+        <a href="/contacto">Ejercer derechos: legal@gano.digital</a>
+      </p>
+
+    </div>
+  </section>
+
+</main>
+<?php get_footer(); ?>

--- a/wp-content/themes/gano-child/templates/page-sla.php
+++ b/wp-content/themes/gano-child/templates/page-sla.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Template Name: Acuerdo de Nivel de Servicio (SLA)
+ * @package gano-child
+ */
+get_header();
+$fecha_actualizacion = '2026-04-06';
+?>
+
+<main id="gano-main-content" class="gano-trust-page gano-legal">
+
+  <section class="gano-dark-section gano-trust-hero">
+    <div class="gano-container">
+      <p class="gano-label-pill">Legal</p>
+      <h1>Acuerdo de Nivel de Servicio</h1>
+      <p class="gano-trust-hero__sub">
+        Última actualización: <?php echo esc_html($fecha_actualizacion); ?>.
+        Compromisos de disponibilidad, soporte e incidentes.
+      </p>
+    </div>
+  </section>
+
+  <section class="gano-trust-section">
+    <div class="gano-container gano-el-prose-narrow gano-legal__body">
+
+      <div class="gano-trust-disclaimer">
+        <p>
+          <strong>Aviso importante.</strong> Los compromisos de disponibilidad de Gano Digital están
+          condicionados a los niveles de servicio de GoDaddy como proveedor de infraestructura.
+          Gano Digital actúa como operador autorizado y no puede garantizar disponibilidad
+          superior a la que GoDaddy garantiza en su propio SLA.
+          <a href="https://www.godaddy.com/es/legal" target="_blank" rel="noopener">Ver términos GoDaddy →</a>
+        </p>
+      </div>
+
+      <section aria-labelledby="sla-disponibilidad">
+        <h2 id="sla-disponibilidad">1. Objetivo de disponibilidad</h2>
+        <p>
+          <!-- [NIT_PENDIENTE]: Confirmar % real con GoDaddy para el plan contratado antes de publicar.
+               No usar "99,9%" sin respaldo escrito. -->
+          Gano Digital persigue mantener el servicio disponible de acuerdo con el plan contratado.
+          El porcentaje de disponibilidad comprometido se especifica en el contrato individual de servicio.
+        </p>
+        <p>
+          El cómputo de disponibilidad excluye: mantenimientos programados comunicados con antelación,
+          incidentes causados por la infraestructura de GoDaddy fuera del control de Gano Digital,
+          y modificaciones del cliente que generen la incidencia.
+        </p>
+      </section>
+
+      <section aria-labelledby="sla-mantenimiento">
+        <h2 id="sla-mantenimiento">2. Ventana de mantenimiento</h2>
+        <p>
+          <!-- [NIT_PENDIENTE]: Definir ventana real. Ej: domingos 02:00–04:00 hora Colombia. -->
+          Los mantenimientos planificados se comunicarán con al menos 48 horas de antelación
+          por correo electrónico al titular de la cuenta.
+        </p>
+      </section>
+
+      <section aria-labelledby="sla-incidentes">
+        <h2 id="sla-incidentes">3. Clasificación y tiempos de respuesta a incidentes</h2>
+        <table class="gano-sla-table">
+          <thead>
+            <tr>
+              <th scope="col">Severidad</th>
+              <th scope="col">Descripción</th>
+              <th scope="col">Tiempo de respuesta</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Crítico</strong></td>
+              <td>Sitio completamente caído; sin acceso a wp-admin</td>
+              <td><!-- [NIT_PENDIENTE] --> Por confirmar</td>
+            </tr>
+            <tr>
+              <td><strong>Alto</strong></td>
+              <td>Degradación severa del rendimiento o funcionalidades clave afectadas</td>
+              <td><!-- [NIT_PENDIENTE] --> Por confirmar</td>
+            </tr>
+            <tr>
+              <td><strong>Medio</strong></td>
+              <td>Funcionalidad parcial; workaround disponible</td>
+              <td><!-- [NIT_PENDIENTE] --> Por confirmar</td>
+            </tr>
+            <tr>
+              <td><strong>Bajo</strong></td>
+              <td>Consultas, mejoras, solicitudes no urgentes</td>
+              <td><!-- [NIT_PENDIENTE] --> Por confirmar</td>
+            </tr>
+          </tbody>
+        </table>
+        <p style="font-size:.875rem; color:#64748b; margin-top:.75rem;">
+          * Los tiempos de respuesta serán confirmados y publicados antes de la activación comercial del plan.
+        </p>
+      </section>
+
+      <section aria-labelledby="sla-reporte">
+        <h2 id="sla-reporte">4. Canal de reporte de incidentes</h2>
+        <ul>
+          <li>Correo: <a href="mailto:soporte@gano.digital">soporte@gano.digital</a></li>
+          <li>WhatsApp: <a href="https://wa.me/573135646123">+57 313 564 6123</a></li>
+        </ul>
+        <p>Indicar siempre: dominio afectado, descripción del problema y hora del primer síntoma.</p>
+      </section>
+
+      <section aria-labelledby="sla-exclusiones">
+        <h2 id="sla-exclusiones">5. Exclusiones</h2>
+        <ul>
+          <li>Ataques DDoS que superen la capacidad de mitigación del proveedor de infraestructura.</li>
+          <li>Fallos de infraestructura de GoDaddy fuera del control de Gano Digital.</li>
+          <li>Modificaciones realizadas por el cliente en su instalación WordPress que generen la incidencia.</li>
+          <li>Mantenimientos programados comunicados con antelación.</li>
+          <li>Eventos de fuerza mayor.</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="sla-compensacion">
+        <h2 id="sla-compensacion">6. Compensación por incumplimiento</h2>
+        <p>
+          <!-- [NIT_PENDIENTE]: Definir política de compensación antes de publicar.
+               Ej: crédito de servicio proporcional al tiempo de caída; no aplica a incidentes GoDaddy. -->
+          La política de compensación por incumplimiento del SLA se especificará en el contrato
+          individual de servicio antes de la activación comercial del plan.
+        </p>
+      </section>
+
+      <hr style="margin:2rem 0; border-color:#e2e8f0;">
+      <p class="gano-legal__footer-links">
+        <a href="/legal/terminos-y-condiciones">Términos y Condiciones</a>
+        &nbsp;·&nbsp;
+        <a href="/contacto">Reportar incidente</a>
+      </p>
+
+    </div>
+  </section>
+
+</main>
+
+<style>
+.gano-sla-table { width: 100%; border-collapse: collapse; font-size: .875rem; margin-top: 1rem; }
+.gano-sla-table th, .gano-sla-table td { padding: .75rem 1rem; border-bottom: 1px solid #e2e8f0; text-align: left; }
+.gano-sla-table thead th { background: #f8fafc; font-weight: 600; }
+.gano-legal__body h2 { font-size: var(--gano-fs-xl, 1.25rem); margin: 2rem 0 .75rem; }
+.gano-legal__body p, .gano-legal__body li { line-height: 1.75; }
+.gano-legal__body ul { padding-left: 1.25rem; }
+.gano-legal__footer-links { font-size: .875rem; color: #64748b; }
+.gano-legal__footer-links a { color: var(--gano-blue, #2952CC); }
+</style>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/gano-child/templates/page-terminos.php
+++ b/wp-content/themes/gano-child/templates/page-terminos.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Template Name: Términos y Condiciones
+ * @package gano-child
+ */
+get_header();
+$fecha_actualizacion = '2026-04-06'; // Actualizar antes de publicar
+?>
+
+<main id="gano-main-content" class="gano-trust-page gano-legal">
+
+  <section class="gano-dark-section gano-trust-hero">
+    <div class="gano-container">
+      <p class="gano-label-pill">Legal</p>
+      <h1>Términos y Condiciones</h1>
+      <p class="gano-trust-hero__sub">
+        Última actualización: <?php echo esc_html($fecha_actualizacion); ?>.
+        Versión en español Colombia. Ley aplicable: República de Colombia.
+      </p>
+    </div>
+  </section>
+
+  <section class="gano-trust-section">
+    <div class="gano-container gano-el-prose-narrow gano-legal__body">
+
+      <section aria-labelledby="tc-identificacion">
+        <h2 id="tc-identificacion">1. Identificación del prestador</h2>
+        <ul>
+          <li><strong>Razón social:</strong> <!-- [NIT_PENDIENTE]: Razón social exacta en Cámara de Comercio --> Gano Digital</li>
+          <li><strong>NIT:</strong> <!-- [NIT_PENDIENTE] --> [NIT_PENDIENTE]-[dígito de verificación]</li>
+          <li><strong>Domicilio:</strong> <!-- [NIT_PENDIENTE]: Dirección fiscal Colombia --> Colombia</li>
+          <li><strong>Correo legal:</strong> <a href="mailto:legal@gano.digital">legal@gano.digital</a></li>
+          <li><strong>Teléfono / WhatsApp:</strong> <a href="https://wa.me/573135646123">+57 313 564 6123</a></li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="tc-objeto">
+        <h2 id="tc-objeto">2. Objeto del servicio</h2>
+        <p>
+          Gano Digital provee ecosistemas de hosting WordPress administrado —bajo las marcas
+          Núcleo Prime, Fortaleza Delta, Bastión SOTA y Ultimate WP— sobre infraestructura
+          aprovisionada a través del programa de reseller de GoDaddy, Inc.
+        </p>
+        <div class="gano-trust-disclaimer">
+          <p>
+            <strong>Transparencia de infraestructura.</strong> Los servicios de Gano Digital son provistos
+            sobre infraestructura operada por GoDaddy, Inc. a través de su programa de reseller.
+            El usuario reconoce que las condiciones técnicas de la infraestructura subyacente están
+            sujetas a los términos de servicio de GoDaddy, disponibles en
+            <a href="https://www.godaddy.com/es/legal" target="_blank" rel="noopener">godaddy.com/es/legal</a>.
+          </p>
+        </div>
+      </section>
+
+      <section aria-labelledby="tc-precios">
+        <h2 id="tc-precios">3. Precios y facturación</h2>
+        <ul>
+          <li>Los precios se expresan en pesos colombianos (COP) e incluyen IVA, salvo indicación expresa.</li>
+          <li>Pueden variar por fluctuación del tipo de cambio USD/COP aplicado al margen del reseller.</li>
+          <li>Facturación electrónica según normativa DIAN <!-- [NIT_PENDIENTE]: confirmar obligatoriedad según volumen -->.</li>
+          <li>Los precios publicados son indicativos; el valor definitivo se confirma en el carrito de pago.</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="tc-disponibilidad">
+        <h2 id="tc-disponibilidad">4. Disponibilidad del servicio</h2>
+        <p>
+          Gano Digital persigue un objetivo de disponibilidad acorde al plan contratado.
+          <!-- [NIT_PENDIENTE]: No publicar porcentaje concreto sin SLA escrito de GoDaddy para el plan.
+               Sustituir esta nota con el % real antes de publicar. -->
+          Los compromisos de disponibilidad están condicionados a los niveles de servicio de GoDaddy
+          como proveedor de infraestructura. Ver
+          <a href="/legal/acuerdo-de-nivel-de-servicio">Acuerdo de Nivel de Servicio</a>.
+        </p>
+      </section>
+
+      <section aria-labelledby="tc-soporte">
+        <h2 id="tc-soporte">5. Soporte técnico</h2>
+        <ul>
+          <li><strong>Canal principal:</strong> <a href="mailto:soporte@gano.digital">soporte@gano.digital</a></li>
+          <li><strong>WhatsApp:</strong> <a href="https://wa.me/573135646123">+57 313 564 6123</a></li>
+          <li><!-- [NIT_PENDIENTE]: Definir horario y tiempo de respuesta comprometido por plan --></li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="tc-cancelacion">
+        <h2 id="tc-cancelacion">6. Cancelación y portabilidad</h2>
+        <ul>
+          <li>El usuario puede cancelar su servicio en cualquier momento contactando a <a href="mailto:soporte@gano.digital">soporte@gano.digital</a>.</li>
+          <li>Gano Digital facilita la exportación de datos y contenido WordPress antes de la cancelación efectiva.</li>
+          <li>Política de reembolsos: <!-- [NIT_PENDIENTE]: definir política antes de publicar -->.</li>
+          <li>Los dominios registrados no son reembolsables tras la activación.</li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="tc-responsabilidad">
+        <h2 id="tc-responsabilidad">7. Limitación de responsabilidad</h2>
+        <p>
+          Gano Digital no responde por caídas o degradaciones causadas por la infraestructura de GoDaddy
+          más allá de lo que GoDaddy cubre en su propio SLA. La responsabilidad máxima de Gano Digital
+          frente al usuario se limita al valor del servicio mensual contratado.
+        </p>
+      </section>
+
+      <section aria-labelledby="tc-ley">
+        <h2 id="tc-ley">8. Ley aplicable y jurisdicción</h2>
+        <p>
+          Estos Términos se rigen por las leyes de la República de Colombia.
+          Para cualquier controversia, las partes se someten a la jurisdicción de los jueces
+          y tribunales de Bogotá D.C., Colombia.
+        </p>
+      </section>
+
+      <hr style="margin:2rem 0; border-color:#e2e8f0;">
+      <p class="gano-legal__footer-links">
+        <a href="/legal/politica-de-privacidad">Política de Privacidad</a>
+        &nbsp;·&nbsp;
+        <a href="/legal/acuerdo-de-nivel-de-servicio">Acuerdo de Nivel de Servicio</a>
+        &nbsp;·&nbsp;
+        <a href="/contacto">Preguntas: contáctanos</a>
+      </p>
+
+    </div>
+  </section>
+
+</main>
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary

- **cd-content-004**: 5 plantillas PHP de trust pages — nosotros, contacto, términos y condiciones, política de privacidad, SLA. Incluye WhatsApp +573135646123, placeholders `[NIT_PENDIENTE]`, cumplimiento Ley 1581/2012.
- **cd-content-005**: CSS `gano-menu-cta` para CTA naranja en header nav; shortcode `[gano_footer_legal]` para Elementor; 4 preguntas FAQ adicionales al schema JSON-LD homepage (candidatos C04/C07/C09/C10 sin placeholders).
- **cd-content-006**: Plantilla `404.php` con copy de marca; microcopy WooCommerce carrito vacío (filtro `woocommerce_empty_cart_message`); dimensiones OG explícitas (`og:image:width/height/type`) en `gano_og_fallback()`.

## Páginas creadas
| Template | Ruta | Estado |
|---|---|---|
| Nosotros | `/nosotros` | Requiere crear página WP y asignar template |
| Contacto | `/contacto` | Requiere registrar action `gano_contacto_submit` en MU plugin |
| Términos | `/legal/terminos-y-condiciones` | [NIT_PENDIENTE] — completar antes de publicar |
| Privacidad | `/legal/politica-de-privacidad` | [NIT_PENDIENTE] — completar antes de publicar |
| SLA | `/legal/acuerdo-de-nivel-de-servicio` | Tiempos de respuesta [NIT_PENDIENTE] |

## Pendiente (acción manual de Diego)
- [ ] Crear páginas WP en wp-admin y asignar template correspondiente
- [ ] Completar `[NIT_PENDIENTE]` con razón social, NIT y dirección fiscal real
- [ ] Asignar CSS class `gano-menu-cta` al ítem "Elegir plan →" en wp-admin → Menús
- [ ] Crear imágenes OG 1200×630 WebP (spec: `memory/content/social-preview-spec-wave3.md`)
- [ ] Subir imágenes OG a WordPress Media Library → `/wp-content/uploads/og/`

## Test plan
- [ ] PHP lint: `php -l wp-content/themes/gano-child/functions.php`
- [ ] Verificar 404 en `/cualquier-ruta-inexistente`
- [ ] Añadir producto al carrito y vaciarlo — confirmar microcopy Gano
- [ ] Inspeccionar `<head>` en homepage — confirmar 4 nuevas FAQ en schema JSON-LD
- [ ] Inspeccionar `<head>` sin Rank Math — confirmar `og:image:width/height/type`
- [ ] Navegar con Tab en header — confirmar `.gano-menu-cta` con botón naranja
- [ ] `[gano_footer_legal]` en Elementor HTML widget — confirmar footer legal

🤖 Generated with [Claude Code](https://claude.com/claude-code)