### PR TITLE
docs(memoria) + fix(security): clarificación Fase 4, seguridad scripts Obsidian y hardening tooling

### DIFF
--- a/.cursor/memory/techContext.md
+++ b/.cursor/memory/techContext.md
@@ -9,6 +9,7 @@
 | Addons                   | Royal Elementor Addons             | Latest                                                               |
 | Commerce                 | WooCommerce                        | Latest                                                               |
 | Checkout / pagos cliente | GoDaddy Reseller Store             | Marca blanca (RCC + Store); pasarelas locales solo legacy si existen |
+| APIs REST GoDaddy (Developer) | Opcional / fuera de WP        | Herramientas o integraciones server-side; no sustituyen Store; Good as Gold solo si la API compra productos ([getstarted](https://developer.godaddy.com/getstarted)) |
 | Seguridad                | Wordfence + gano-security.php      | Custom                                                               |
 | SEO                      | Rank Math + gano-seo.php           | Custom                                                               |
 | Tema                     | gano-child (Hello Elementor child) | Custom                                                               |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ Antes de asumir que el repo es idéntico a producción, lee **[`.github/DEV-COOR
 - **CMS**: WordPress 6.x + Elementor Pro + Royal Elementor Addons
 - **E-commerce**: WooCommerce (moneda COP, zona Bogotá)
 - **Pagos / checkout**: **GoDaddy Reseller Store** (marca blanca). No priorizar Wompi ni pasarelas locales salvo código legacy explícito en el repo.
+- **GoDaddy Developer API (REST)**: **opcional** — herramientas o integraciones fuera del núcleo vitrina/RCC; no sustituye el carrito Reseller. **Good as Gold** solo si la API **compra** productos que debiten prepago ([getstarted](https://developer.godaddy.com/getstarted)). Nunca commitear Key/Secret. Matriz y ToU: `memory/research/sota-apis-mercadolibre-godaddy-2026-04.md` (§3.7).
 - **Seguridad**: Wordfence + MU Plugin `gano-security.php`
 - **SEO**: Rank Math + MU Plugin `gano-seo.php`
 - **Tema**: Hello Elementor → `gano-child` (child theme)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Plan actual donde está alojado gano.digital. Relevante para saber qué tenemos 
 | **plugins de fase** | gano-phase1..7 — instaladores del sitio (ver nota crítica) |
 | **MU plugin** | gano-security.php en /mu-plugins/ — seguridad base |
 | **Reseller** | Programa GoDaddy Reseller: catálogo, checkout y cobro al cliente final (ver `TASKS.md` Fase 4). |
+| **Developer API (GoDaddy)** | Herramientas **opcionales** (REST, Key/Secret): automatización o consultas **fuera** del núcleo vitrina/RCC. **No** requiere Good as Gold hasta que la API **compre** productos que debiten prepago. **No** implica cambiar plugins salvo decisión explícita. Ver `memory/research/sota-apis-mercadolibre-godaddy-2026-04.md` §3.7. |
 | **ecosistemas** | Los 4 planes de hosting de Gano Digital |
 | **skills** | Scripts de guía en .gano-skills/ |
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -80,7 +80,7 @@ _Última actualización: Abril 2026_
 
 ## 📋 Fase 4 — Integración GoDaddy Reseller (Agilizada)
 
-**ESTRATEGIA ACTUALIZADA**: Toda la facturación y el checkout recaen sobre el API y Carrito nativo de GoDaddy Reseller. Se elimina el overhead de mantener paneles de facturación locales (WHMCS) y gateways de pago propios.
+**ESTRATEGIA ACTUALIZADA**: Toda la facturación y el checkout recaen sobre el **carrito y el programa nativos** del GoDaddy Reseller (RCC + Reseller Store), no sobre la **API REST** del Developer Portal. Esa API es **opcional** solo como herramienta complementaria (scripts, back-office, futuro billing); **Good as Gold** aplica cuando haya **compras** vía API, no para uso meramente consultivo. Se elimina el overhead de mantener paneles de facturación locales (WHMCS) **mientras** el modelo activo sea Reseller; `memory/research/fase4-plataforma.md` queda como referencia para expansiones posteriores.
 
 - [ ] **Depurar Catálogo en GoDaddy Reseller Control Center**:
   - Asegurar que los productos (Hosting, VPS, SSL) tengan el precio base en el RCC (Reseller Control Center).

--- a/memory/commerce/rcc-pfid-checklist.md
+++ b/memory/commerce/rcc-pfid-checklist.md
@@ -2,6 +2,8 @@
 
 Este documento detalla los pasos para obtener los identificadores de producto (**PFIDs**) desde el **Reseller Control Center (RCC)** de GoDaddy y vincularlos con la vitrina de Gano Digital.
 
+> **Nota:** El **Developer API** ([getstarted](https://developer.godaddy.com/getstarted)) es independiente de este flujo: el checkout canónico sigue siendo **Reseller Store + RCC**. Las claves REST son opcionales para otras herramientas; no son necesarias para mapear PFIDs.
+
 ## 🔒 Privacidad y Seguridad
 > [!WARNING]
 > Los **PFIDs** y el **Private Label ID (PLID)** son identificadores públicos del catálogo, pero se recomienda completar este paso directamente en el servidor (`wp-config.php` o `functions.php`) para no commitear valores reales al repositorio si prefieres mantener el catálogo en privado durante el desarrollo.

--- a/memory/projects/gano-digital.md
+++ b/memory/projects/gano-digital.md
@@ -9,6 +9,10 @@ Proveedor de ecosistemas de hosting de alto rendimiento (SOTA - State of the Art
 
 **Modelo de negocio actualizado**: Marca blanca basada en el programa GoDaddy Reseller. GoDaddy maneja el inventario, aprovisionamiento, facturación y pagos de los clientes (carrito de marca blanca). Gano Digital actúa como la vitrina de alto impacto (Kinetic Monolith) y orquesta el marketing/branding SOTA.
 
+### GoDaddy Developer API (REST) — herramientas opcionales
+
+Las claves del [portal de desarrolladores](https://developer.godaddy.com/getstarted) sirven para **complementar** el negocio (consultas, automatización interna, integraciones futuras fuera de WordPress). **No** sustituyen el Reseller Store ni obligan a tocar plugins. **[Good as Gold](https://developer.godaddy.com/getstarted)** solo entra en juego cuando se **compran** productos a través de la API (debitan el prepago); si el uso es solo herramientas o lecturas que no ejecutan esa compra, puede **posponerse**. Detalle técnico y ToU: `memory/research/sota-apis-mercadolibre-godaddy-2026-04.md`.
+
 ## Stack tecnológico completo
 - WordPress 6.x + Elementor + Royal Elementor Addons
 - GoDaddy Reseller Store Plugin — Importador de catálogo y redirección al carrito

--- a/memory/research/sota-apis-mercadolibre-godaddy-2026-04.md
+++ b/memory/research/sota-apis-mercadolibre-godaddy-2026-04.md
@@ -2,7 +2,7 @@
 
 **Ámbito:** documentación pública accesible desde los hubs oficiales ([Mercado Libre API Docs — Colombia](https://developers.mercadolibre.com.co/es_ar/api-docs-es), [GoDaddy Developer Portal](https://developer.godaddy.com/)).  
 **Fecha de captura:** 2026-04-03.  
-**Uso previsto:** referencia interna para integraciones opcionales (automatización, Reseller, catálogo, dominios) sin sustituir el roadmap actual de Gano Digital (WordPress + GoDaddy Reseller Store + Wompi donde aplique).
+**Uso previsto:** referencia interna para **herramientas opcionales** (automatización, consultas, dominios) sin sustituir el roadmap actual de Gano Digital (**WordPress + GoDaddy Reseller Store + RCC**). Las APIs REST del [Developer Portal](https://developer.godaddy.com/) **no** sustituyen el carrito ni exigen cambios en plugins: solo complementan (scripts, back-office, futuros sistemas como WHMCS) cuando haga falta.
 
 ---
 
@@ -143,8 +143,16 @@ Implica que cuentas “pequeñas” pueden **no** tener acceso completo a cierta
 
 ### 3.6 Pagos y facturación vía API
 
-- **Good as Gold:** cuenta prepago para compras (p. ej. dominios); la API descuenta tarifas fijas.
-- **Sin pasarela:** la API **no** provee procesador para cobrar a *tus* clientes finales — debes integrar cobro propio (coherente con modelo Reseller + billing aparte).
+- **Good as Gold:** según [Get Started](https://developer.godaddy.com/getstarted), hace falta **cuando la API debe completar compras** (p. ej. registrar un dominio): la API descuenta tarifas fijas de esa cuenta prepago. **No** es requisito para “tener claves” ni para todo uso de herramientas: si solo exploras, consultas o integras flujos que **no** debitan productos vía API, puede **omitirse** hasta que ese flujo exista.
+- **Sin pasarela:** la API **no** provee procesador para cobrar a *tus* clientes finales — debes integrar cobro propio (coherente con modelo **API Reseller**; el **checkout de vitrina** sigue siendo Reseller Store + RCC cuando no automatizas la compra vía REST).
+
+### 3.7 Alineación con el proyecto Gano Digital (2026-04)
+
+| Camino | Rol |
+|--------|-----|
+| **Reseller Store + RCC + `gano-reseller-enhancements`** | **Canónico** para catálogo, CTAs y checkout marca blanca. Sin dependencia de Good as Gold en ese flujo. |
+| **Developer API (Key/Secret, OTE / prod)** | **Opcional**: soporte interno, conciliación, automatización futura, integración con billing aparte. **Redundante** si RCC + informes cubren la operación; **evitar** duplicar fuentes de verdad sin proceso. |
+| **Plugins WordPress** | **No** es necesario modificarlos para “usar” las APIs: credenciales y llamadas deben vivir **fuera del front** (servidor propio, scripts, n8n, WHMCS, etc.). |
 
 ---
 

--- a/memory/research/sota-operativo-2026-04.md
+++ b/memory/research/sota-operativo-2026-04.md
@@ -39,7 +39,7 @@ Esto refuerza el playbook local: `.github/prompts/copilot-bulk-assign.md`, `MERG
 
 ## Integraciones externas (referencia de investigación)
 
-- Resumen de portales **Mercado Libre Developers** y **GoDaddy Developer API** (sin credenciales): [`sota-apis-mercadolibre-godaddy-2026-04.md`](sota-apis-mercadolibre-godaddy-2026-04.md).
+- Resumen de portales **Mercado Libre Developers** y **GoDaddy Developer API** (sin credenciales): [`sota-apis-mercadolibre-godaddy-2026-04.md`](sota-apis-mercadolibre-godaddy-2026-04.md) — incluye **§3.7** (API REST como complemento opcional; Good as Gold solo para compras vía API; vitrina = Reseller Store + RCC).
 - Cola delegable para profundizar: `.github/agent-queue/tasks-api-integrations-research.json`.
 
 ---


### PR DESCRIPTION
## Resumen

- **Clarificación Fase 4**: `TASKS.md` y documentación de agentes reflejan que el checkout usa el carrito/RCC nativo de GoDaddy Reseller — **no** la REST API del Developer Portal. Good as Gold solo aplica cuando la API debita compras.
- **Seguridad scripts Obsidian**: eliminadas API keys hardcodeadas de todos los scripts (`Sync-Obsidian.ps1`, `sync-obsidian-simple.ps1`, `sync-gano-obsidian.bat`, `sync_obsidian.sh`, `obsidian_sync_api.py`, `obsidian_live_monitor.py`) y de `OBSIDIAN-MCP-SETUP.md`; todos leen el token desde la variable de entorno `OBSIDIAN_API_KEY`.
- **TLS bypass acotado**: reemplazado el override global de `ServicePointManager`/`ServerCertificateValidationCallback` por `-SkipCertificateCheck` por-request (PS7) y `verify=False` en Python, ambos con validación explícita de host `localhost`.
- **XSS Ops Hub**: `s.name` y `note` ahora pasan por `esc()` antes de interpolarse en `innerHTML` en `tools/gano-ops-hub/public/index.html`.
- **Tooling IDE**: corregidos `pathMapping` → `pathMappings` y `show_log` → `log` en `.vscode/launch.json`; consolidada la clave `[markdown]` duplicada en `.vscode/settings-expanded.json`.
- **Scripts y docs**: añadida verificación de `jq` en `sync_obsidian.sh`; timeouts de 10 s en `obsidian_sync_api.py`; rutas locales (`C:\Users\diego\...`) reemplazadas por placeholders en documentación; typo `Update-ConstelationStatus` → `Update-ConstellationStatus`.
- **Workflow y README**: eliminado `dispatch-state.json` del trigger de `gano-ops-hub.yml` (archivo en `.gitignore`); README aclara que no se versiona; añadida validación de rama y dirty-tree en `publish-gano-ops-gh-pages.ps1` antes del borrado recursivo.

## Área

- [ ] Tema `gano-child`
- [ ] MU-plugins / seguridad
- [ ] Plugins `gano-*`
- [x] CI / GitHub
- [ ] Contenido / Elementor (nota: mucho vive en BD; documenta IDs o export)

## Checklist

- [x] No se añaden credenciales, tokens ni rutas con usuario de hosting en claro.
- [ ] Si toca checkout/Reseller o plugins de pago: revisado según `TASKS.md` y sin secretos en claro.
- [x] `php -l` local en archivos tocados (o confío en CI).
- [ ] Si el cambio ya está en servidor o diverge de prod: actualicé [`DEV-COORDINATION.md`](.github/DEV-COORDINATION.md) / `TASKS.md` o abrí issue **[sync]**.

## Notas para Copilot / revisores

Todos los secretos Obsidian hardcodeados han sido eliminados del historial visible de esta rama y reemplazados por lectura desde `OBSIDIAN_API_KEY`. **Se recomienda rotar la key en Obsidian Local REST API** ya que el valor estuvo expuesto en commits anteriores de esta rama.

El PR abarca documentación Fase 4, scripts de sincronización Obsidian y configuración de tooling IDE/CI — alcance más amplio que el título original; se unificó en un solo PR por coherencia de la rama. Pasan **TruffleHog**, **PHP lint** y **CodeQL** (0 alertas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)