### PR TITLE
chore(ops): SSH CI docs + Ops Hub progress

### DIFF
--- a/.cursor/memory/activeContext.md
+++ b/.cursor/memory/activeContext.md
@@ -1,6 +1,6 @@
 # Active Context — Estado Actual
 
-_Última actualización: 2026-04-07 (investigación SOTA workflow paralelo + registro en `memory/research/`)_
+_Última actualización: 2026-04-08 (repo local sincronizado con `origin/main`; enlaces ops SSH en `DEV-COORDINATION` + regeneración `progress.json` coherente con `TASKS.md`)_
 
 ## Foco actual (producto y repo)
 
@@ -26,22 +26,15 @@ _Última actualización: 2026-04-07 (investigación SOTA workflow paralelo + reg
 
 ## En progreso
 
-- [ ] SSH key / acceso: validar autorización real de la clave actual contra GitHub y servidor; el transporte responde, pero la autenticación por clave sigue fallando.
+- [ ] **CI Deploy (04):** si falla en *Setup SSH Agent* con `error in libcrypto`, corregir el secret `SSH` (OpenSSH/ed25519 sin passphrase, LF, no `.ppk`) — [`memory/ops/github-actions-ssh-secret-troubleshooting.md`](../../memory/ops/github-actions-ssh-secret-troubleshooting.md).
+- [ ] SSH key / acceso local: validar autorización de la clave contra GitHub y servidor cuando aplique el flujo manual.
 - [ ] SFTP / sync VS Code si aplica al flujo de deploy de Diego.
 - [ ] Deploy de archivos críticos al servidor y tareas solo-wp-admin listadas en `TASKS.md`.
 
-## GitHub — PRs abiertos (auditoría 2026-04-07)
+## GitHub — PRs y merges
 
-Repo `Gano-digital/Pilot`: **9 PRs abiertos** (#136 + #145–#152). **Ninguno fusionable vía `gh merge` desde esta sesión:** ruleset org **«Gano.digital»** bloquea merge con **«Code quality findings»** (incluso `--admin` en #136). Además **#136** no puede autoaprobarse (autor = mismo usuario).
-
-| PR | Rama | Estado | mergeable | Notas |
-|----|------|--------|-----------|--------|
-| 136 | docs/memoria-fase4… | OPEN | MERGEABLE pero **merge blocked** por política | CI: validate, TruffleHog, CodeQL jobs OK |
-| 145–152 | copilot/cx-* | DRAFT | 147 **CONFLICTING**; resto MERGEABLE | Constellation oleada; squash sugerido |
-
-**Desbloqueo manual en GitHub:** Security / Code scanning o reglas del PR → revisar o descartar hallazgos que exija el ruleset; u otra cuenta con permiso **aprueba** #136. Luego `gh pr merge 136 --squash` o botón Merge.
-
-**#147:** antes de merge, actualizar rama con `main` (resolver conflictos) vía UI «Update branch» o merge local.
+- **Estado dinámico:** revisar con `gh pr list --repo Gano-digital/Pilot` o la pestaña Pull requests. Varios PRs históricos pueden estar ya fusionados en `main`; no usar tablas de auditoría antigua como fuente de verdad sin verificar.
+- **Ruleset «Code quality» / CodeQL:** si un PR queda bloqueado por hallazgos de escaneo, el desbloqueo es en la UI de GitHub (Security / reglas del PR).
 
 ## Bloqueadores
 

--- a/.cursor/memory/progress.md
+++ b/.cursor/memory/progress.md
@@ -1,5 +1,16 @@
 # Progress Tracker
 
+## 2026-04-08 — Ops: enlaces SSH CI + artefacto Ops Hub
+
+### Completado
+
+- [x] Enlace explícito a [`memory/ops/github-actions-ssh-secret-troubleshooting.md`](../memory/ops/github-actions-ssh-secret-troubleshooting.md) desde `.github/DEV-COORDINATION.md` y comentario en `deploy.yml`.
+- [x] Sección de actualización en `memory/ops/github-actions-audit-2026-04.md` (workflows 13–14 + troubleshooting).
+- [x] Regenerado `tools/gano-ops-hub/public/data/progress.json` con `scripts/generate_gano_ops_progress.py` (alineado a `TASKS.md` actual).
+- [x] `.cursor/memory/activeContext.md` — tabla de PRs obsoleta sustituida por instrucción dinámica; foco deploy CI + SSH.
+
+---
+
 ## 2026-04-07 — Battle Map: plan diseño + fine tuning + agentes
 
 ### Completado (documentación + marca en HTML)

--- a/.github/DEV-COORDINATION.md
+++ b/.github/DEV-COORDINATION.md
@@ -82,6 +82,8 @@ Ejecuta **06 · Repo · Crear etiquetas** si faltan etiquetas; sin ellas el labe
 
 **Secrets de deploy (Settings → Secrets and variables → Actions):** además de `SSH` (clave privada), define `SERVER_HOST` (hostname o IP para `ssh-keyscan`), `SERVER_USER` (usuario SSH/SFTP) y `DEPLOY_PATH` (ruta absoluta al `public_html` o raíz WP, **sin** barra final inconsistente). Sin estos cuatro, el job de deploy fallará al expandir rutas.
 
+Si **04 / 05 / 12** fallan en *Setup SSH Agent* con `error in libcrypto` / `ssh-add`, el contenido del secret `SSH` no es PEM/OpenSSH válido para CI (p. ej. `.ppk`, CRLF, passphrase). Guía: [`memory/ops/github-actions-ssh-secret-troubleshooting.md`](../memory/ops/github-actions-ssh-secret-troubleshooting.md).
+
 ---
 
 ## 5. Desarrollo local (recordatorio)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   # JOB 2: Deploy Theme + Plugins via SSH
   # Requiere secrets: SSH, SERVER_HOST, SERVER_USER, DEPLOY_PATH
+  # ssh-add / libcrypto: memory/ops/github-actions-ssh-secret-troubleshooting.md
   # ──────────────────────────────────────────────────────────────────────────
   deploy:
     name: 🚀 Deploy to ${{ github.event.inputs.environment || 'production' }}

--- a/memory/ops/github-actions-audit-2026-04.md
+++ b/memory/ops/github-actions-audit-2026-04.md
@@ -72,10 +72,16 @@
 
 ---
 
+## Actualización 2026-04-08
+
+- Workflows **13** (`project-add-to-project.yml`) y **14** (`gano-ops-hub.yml`) añadidos tras la auditoría inicial; inventario ampliado en [`.github/workflows/README.md`](../../.github/workflows/README.md).
+- Fallo típico **04 / 05 / 12** con clave SSH en CI: [`github-actions-ssh-secret-troubleshooting.md`](github-actions-ssh-secret-troubleshooting.md).
+
 ## Referencias
 
-- [`../.github/workflows/README.md`](../.github/workflows/README.md) — prefijos 01–12.
+- [`../.github/workflows/README.md`](../.github/workflows/README.md) — prefijos 01–14.
 - [`../.github/MERGE-PLAYBOOK.md`](../.github/MERGE-PLAYBOOK.md) — orden de merges.
+- [`github-actions-ssh-secret-troubleshooting.md`](github-actions-ssh-secret-troubleshooting.md) — formato del secret `SSH` en Actions.
 - `actions/labeler` README: [github.com/actions/labeler](https://github.com/actions/labeler)
 
 _Verificar tras push: Actions → ejecutar un PR de prueba o revisar el siguiente PR para confirmar **03** en verde._

--- a/tools/gano-ops-hub/public/data/progress.json
+++ b/tools/gano-ops-hub/public/data/progress.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
-  "generated_at": "2026-04-07T04:59:06.943190+00:00",
+  "generated_at": "2026-04-08T01:43:46.161816+00:00",
   "repository": "Gano-digital/Pilot",
   "tasks_md": {
-    "total_open": 29,
+    "total_open": 34,
     "total_done": 40,
-    "total_items": 69,
+    "total_items": 74,
     "sections": [
       {
         "name": "REGRESAR AQUÍ (pendiente tu acción)",
@@ -48,13 +48,18 @@
         "done": 0
       },
       {
+        "name": "📋 Etapa posterior — Tests y calidad de ingeniería del código",
+        "open": 5,
+        "done": 0
+      },
+      {
         "name": "🔄 Abril 2026 — Progreso (homepage + GitHub)",
         "open": 12,
         "done": 20
       }
     ]
   },
-  "tasks_completion_pct": 58.0,
+  "tasks_completion_pct": 54.1,
   "dispatch": {
     "queue_total": 22,
     "completed_count": 0,


### PR DESCRIPTION
## Summary
- Enlaza el runbook de troubleshooting (error in libcrypto / ssh-add) desde DEV-COORDINATION y deploy.yml.
- Actualiza la auditoría de Actions con referencia a workflows 13–14.
- Regenera 	ools/gano-ops-hub/public/data/progress.json (alineado a TASKS.md).
- Ajusta el memory bank para que PRs/merges se verifiquen de forma dinámica.

## Test plan
- [ ] Revisar el diff (6 archivos, solo docs/workflow/ops json).
- [ ] (Opcional) Ejecutar workflow 14 para validar que progress.json se publica/actualiza.