### PR TITLE
fix(ci): prechequeo SSH deploy 04 + docs publickey

### DIFF
--- a/.cursor/memory/activeContext.md
+++ b/.cursor/memory/activeContext.md
@@ -1,6 +1,6 @@
 # Active Context — Estado Actual
 
-_Última actualización: 2026-04-08 (repo local sincronizado con `origin/main`; enlaces ops SSH en `DEV-COORDINATION` + regeneración `progress.json` coherente con `TASKS.md`)_
+_Última actualización: 2026-04-08 (merge #156 + #157 en `main`; workflow **14** Ops Hub verde tras fix `generate_gano_ops_progress.py`; workflow **04** Deploy sigue `publickey` hasta alinear secret `SSH` con la misma pareja que el acceso local)_
 
 ## Foco actual (producto y repo)
 
@@ -26,8 +26,8 @@ _Última actualización: 2026-04-08 (repo local sincronizado con `origin/main`; 
 
 ## En progreso
 
-- [ ] **CI Deploy (04):** si falla en *Setup SSH Agent* con `error in libcrypto`, corregir el secret `SSH` (OpenSSH/ed25519 sin passphrase, LF, no `.ppk`) — [`memory/ops/github-actions-ssh-secret-troubleshooting.md`](../../memory/ops/github-actions-ssh-secret-troubleshooting.md).
-- [ ] SSH key / acceso local: validar autorización de la clave contra GitHub y servidor cuando aplique el flujo manual.
+- [ ] **CI Deploy (04):** si `ssh-add` OK pero **rsync** falla con `Permission denied (publickey)`, el secret `SSH` no coincide con la clave autorizada en el servidor para `SERVER_USER@SERVER_HOST`, o el usuario/host en secretos no es el del deploy — [`memory/ops/github-actions-ssh-secret-troubleshooting.md`](../../memory/ops/github-actions-ssh-secret-troubleshooting.md).
+- [x] **Workflow 14 (Ops Hub):** script `--output` relativo corregido en `main` (#157); run manual post-merge: éxito ([24147290218](https://github.com/Gano-digital/Pilot/actions/runs/24147290218)).
 - [ ] SFTP / sync VS Code si aplica al flujo de deploy de Diego.
 - [ ] Deploy de archivos críticos al servidor y tareas solo-wp-admin listadas en `TASKS.md`.
 

--- a/.cursor/memory/progress.md
+++ b/.cursor/memory/progress.md
@@ -1,5 +1,15 @@
 # Progress Tracker
 
+## 2026-04-08 — Merge #156/#157 + billing Actions + verificación workflows
+
+### Completado
+
+- [x] Fusionados en `main`: **#156** (docs SSH CI + `progress.json`) y **#157** (fix ruta relativa `generate_gano_ops_progress.py`).
+- [x] Tras arreglo de **billing** en GitHub, **workflow 14** manual en verde ([run 24147290218](https://github.com/Gano-digital/Pilot/actions/runs/24147290218)).
+- [ ] **Workflow 04** Deploy: sigue fallando en rsync con `publickey` (run [24147291642](https://github.com/Gano-digital/Pilot/actions/runs/24147291642)) — alinear secret `SSH` / usuario / host con el acceso que ya funciona en local.
+
+---
+
 ## 2026-04-08 — Ops: enlaces SSH CI + artefacto Ops Hub
 
 ### Completado

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,28 @@ jobs:
         run: |
           ssh-keyscan -H "${{ secrets.SERVER_HOST }}" >> ~/.ssh/known_hosts
 
+      # Diagnóstico seguro: huella de la clave cargada (no imprime la clave privada).
+      # Comparar con `ssh-keygen -lf ~/.ssh/tu.pub` localmente si el deploy falla con publickey.
+      - name: Huella de clave en ssh-agent
+        run: |
+          set -euo pipefail
+          ssh-add -l -E sha256
+
+      # Falla aquí con el mismo error que rsync → el problema es SSH/auth, no rsync.
+      - name: Probar SSH (BatchMode)
+        env:
+          REMOTE_USER: ${{ secrets.SERVER_USER }}
+          REMOTE_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          ssh -o BatchMode=yes -o ConnectTimeout=25 "${REMOTE_USER}@${REMOTE_HOST}" \
+            "echo SSH_OK && whoami && pwd"
+
+      # Asegura que rsync use el mismo ssh(1) con BatchMode (agente ya cargado).
+      - name: Configurar RSYNC_RSH
+        run: |
+          echo 'RSYNC_RSH=ssh -o BatchMode=yes -o ConnectTimeout=30' >> "$GITHUB_ENV"
+
       - name: 📦 Deploy Child Theme
         run: |
           rsync -avz --delete \

--- a/memory/ops/github-actions-ssh-secret-troubleshooting.md
+++ b/memory/ops/github-actions-ssh-secret-troubleshooting.md
@@ -33,6 +33,14 @@ ssh -o BatchMode=yes SERVER_USER@SERVER_HOST "echo ok"
 
 Si `ssh-add` falla en tu PC con el mismo PEM, el secret en GitHub tampoco funcionará.
 
+## `Permission denied (publickey)` (cuando `ssh-add` ya funciona)
+
+Si el workflow **04** pasa *Setup SSH Agent* pero falla en **rsync** o **ssh** con `Permission denied (publickey)`:
+
+1. El secret **`SSH`** debe ser la **privada** que corresponde a la **misma** `.pub` que está en `~/.ssh/authorized_keys` del **`SERVER_USER`** en el host **`SERVER_HOST`**.
+2. Compara **huellas** (fingerprint): en el log del job, el paso *Huella de clave en ssh-agent* ejecuta `ssh-add -l`; localmente, `ssh-keygen -lf ~/.ssh/tu_clave.pub` debe mostrar la **misma** huella que la entrada del agente en CI.
+3. Verifica que `SERVER_USER` y `SERVER_HOST` en GitHub coincidan exactamente con el par `usuario@host` con el que pruebas en local.
+
 ## Secrets relacionados
 
 - `SERVER_HOST`, `SERVER_USER`, `DEPLOY_PATH` deben coincidir con el usuario que tiene la clave en `authorized_keys`.


### PR DESCRIPTION
## Summary
- **Memory:** estado post-merge #156/#157 y verificación workflow 14 (Ops Hub verde).
- **Deploy 04:** pasos de diagnóstico seguros (ssh-add -l, prueba ssh BatchMode, RSYNC_RSH) para aislar fallos publickey vs rsync.
- **Docs:** sección en troubleshooting para alinear secret SSH / huella / SERVER_*.

## Test plan
- [ ] Tras merge, ejecutar **04 · Deploy** manual y revisar logs del paso *Probar SSH* y *Huella de clave*.