### PR TITLE
refactor(woo): fix hardcoded values en WooCommerce Member Portal

### DIFF
--- a/wp-content/themes/gano-child/style.css
+++ b/wp-content/themes/gano-child/style.css
@@ -11,15 +11,55 @@ Text Domain:  gano-child
 Tags:         hosting, digital-services, colombia
 */
 
-/* Gano Member Portal Styles */
-.woocommerce-account .woocommerce-MyAccount-navigation { background: rgba(15, 17, 21, 0.9); backdrop-filter: blur(10px); border: 1px solid rgba(212, 175, 55, 0.2); border-radius: 12px; padding: 20px; margin-right: 30px; }
+/* START: WOOCOMMERCE MEMBER PORTAL */
+.woocommerce-account .woocommerce-MyAccount-navigation {
+    background: rgba(15, 17, 21, 0.9);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--gano-gold-border);
+    border-radius: var(--gano-radius-lg);
+    padding: 20px;
+    margin-right: 30px;
+}
+
 .woocommerce-account .woocommerce-MyAccount-navigation ul { list-style: none; padding: 0; }
-.woocommerce-account .woocommerce-MyAccount-navigation ul li { border-bottom: 1px solid rgba(255, 255, 255, 0.05); padding: 10px 0; }
-.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a { color: var(--gano-gold, #D4AF37); font-weight: 700; }
-.woocommerce-account .woocommerce-MyAccount-navigation ul li a { color: #94a3b8; text-decoration: none; font-size: 0.95rem; transition: color 0.3s; }
-.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover { color: #fff; }
-.woocommerce-account .woocommerce-MyAccount-content { background: rgba(255, 255, 255, 0.02); border: 1px solid rgba(255, 255, 255, 0.05); border-radius: 12px; padding: 40px; color: #e2e8f0; }
-.gano-portal-card { background: linear-gradient(135deg, var(--gano-gold-soft, rgba(212, 175, 55, 0.1)), rgba(0, 0, 0, 0)); border: 1px solid var(--gano-gold-border, rgba(212, 175, 55, 0.3)); padding: 20px; border-radius: 8px; margin-bottom: 20px; }
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul li {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 10px 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a {
+    color: var(--gano-gold);
+    font-weight: var(--gano-fw-bold);
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul li a {
+    color: var(--gano-text-slate);
+    text-decoration: none;
+    font-size: var(--gano-fs-base);
+    transition: var(--gano-transition);
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover {
+    color: var(--gano-white);
+}
+
+.woocommerce-account .woocommerce-MyAccount-content {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: var(--gano-radius-lg);
+    padding: 40px;
+    color: var(--gano-gray-300);
+}
+
+.gano-portal-card {
+    background: linear-gradient(135deg, var(--gano-gold-soft), transparent);
+    border: 1px solid var(--gano-gold-border);
+    padding: 20px;
+    border-radius: var(--gano-radius-md);
+    margin-bottom: 20px;
+}
+/* END: WOOCOMMERCE MEMBER PORTAL */
 
 /* ============================================================
    TOKENS DE MARCA — GANO DIGITAL


### PR DESCRIPTION
## Resumen

Las primeras 9 líneas de `style.css` tenían los estilos del portal de miembro WooCommerce comprimidos en una línea cada uno, con múltiples valores hardcodeados. Este PR los expande y los conecta al sistema de tokens.

## Cambios

| Propiedad | Antes | Después |
|---|---|---|
| nav color de links | `#94a3b8` | `var(--gano-text-slate)` |
| nav link hover | `#fff` | `var(--gano-white)` |
| content color | `#e2e8f0` | `var(--gano-gray-300)` |
| nav border-radius | `12px` | `var(--gano-radius-lg)` |
| content border-radius | `12px` | `var(--gano-radius-lg)` |
| portal-card border-radius | `8px` | `var(--gano-radius-md)` |
| nav border color | `rgba(212,175,55,0.2)` | `var(--gano-gold-border)` |
| portal-card background | `rgba(212,175,55,0.1)` | `var(--gano-gold-soft)` |
| active link font-weight | `700` | `var(--gano-fw-bold)` |
| link transition | `color 0.3s` | `var(--gano-transition)` |
| link font-size | `0.95rem` | `var(--gano-fs-base)` |

## Plan de prueba
- [ ] Verificar `/mi-cuenta` — el menú lateral debe verse idéntico visualmente
- [ ] Verificar que el link activo sigue en dorado
- [ ] Verificar que hover de links cambia a blanco

🤖 Contribución ARCANA C.A.D.E. — rama `arcana/woo-checkout`