### PR TITLE
feat(hero): overlay oscuro + domain search en paleta de marca

### DIFF
--- a/wp-content/themes/gano-child/style.css
+++ b/wp-content/themes/gano-child/style.css
@@ -1858,3 +1858,122 @@ select:focus-visible {
         transition: none;
     }
 }
+
+/* ============================================================
+   START: HERO OVERLAY + DOMAIN SEARCH FIX
+   Oleada 7 — Legibilidad del Hero y paleta de sección de dominio.
+
+   Instrucciones Elementor:
+   1. Sección hero → Avanzado → Clases CSS → agregar "gano-hero-overlay"
+   2. Sección búsqueda de dominio → Avanzado → Clases CSS → agregar "gano-domain-section"
+   3. Widget H1 del hero → Avanzado → Clases CSS → agregar "gano-el-hero-readability"
+   ============================================================ */
+
+/* — Hero overlay: gradiente oscuro sobre cualquier imagen de fondo — */
+.gano-hero-overlay {
+    position: relative;
+    isolation: isolate;
+}
+
+.gano-hero-overlay::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    background: linear-gradient(
+        135deg,
+        rgba(5, 8, 12, 0.88) 0%,
+        rgba(5, 8, 12, 0.70) 55%,
+        rgba(27, 79, 216, 0.25) 100%
+    );
+}
+
+/* El contenedor de Elementor queda sobre el overlay */
+.gano-hero-overlay > .elementor-container,
+.gano-hero-overlay > .e-con-inner {
+    position: relative;
+    z-index: 2;
+}
+
+/* — Text-shadow fuerte: legible sobre cualquier imagen oscura o texturizada — */
+.gano-el-hero-readability .elementor-heading-title,
+.gano-el-hero-readability h1,
+.gano-el-hero-readability h2 {
+    text-shadow:
+        0 2px 24px rgba(5, 8, 12, 0.92),
+        0 4px 48px rgba(5, 8, 12, 0.75),
+        0 1px 4px  rgba(5, 8, 12, 0.98);
+}
+
+/* — Sección búsqueda de dominios: elimina fondo lavanda del plugin/Elementor — */
+.gano-domain-section,
+.gano-domain-section.elementor-section,
+.gano-domain-section.e-con {
+    background-color: var(--gano-dark-deep, #05080C) !important;
+    background-image: none !important;
+}
+
+/* Selector de respaldo: aplica si la sección contiene el widget del plugin */
+.elementor-section:has(.rstore-domain-search),
+.e-con:has(.rstore-domain-search) {
+    background-color: var(--gano-dark-deep, #05080C) !important;
+    background-image: none !important;
+}
+
+/* Inputs y CTA del buscador de dominios heredan paleta de marca */
+.rstore-domain-search {
+    background: transparent !important;
+    color: var(--gano-text, #E2E8F0);
+}
+
+.rstore-domain-search input[type="text"],
+.rstore-domain-search .rstore-search-input {
+    background: var(--gano-card-sota, #0B1118) !important;
+    border-color: var(--gano-border-sota, rgba(99,102,241,0.20)) !important;
+    color: var(--gano-text, #E2E8F0) !important;
+}
+
+.rstore-domain-search input[type="text"]::placeholder,
+.rstore-domain-search .rstore-search-input::placeholder {
+    color: var(--gano-text-slate, #94A3B8) !important;
+}
+
+.rstore-domain-search .rstore-search-btn,
+.rstore-domain-search button[type="submit"] {
+    background: var(--gano-orange, #EA580C) !important;
+    border-color: var(--gano-orange, #EA580C) !important;
+    color: #ffffff !important;
+}
+
+.rstore-domain-search .rstore-search-btn:hover,
+.rstore-domain-section button[type="submit"]:hover {
+    background: var(--gano-orange-hover, #C2410C) !important;
+    border-color: var(--gano-orange-hover, #C2410C) !important;
+}
+
+/* — Monolith: figura geométrica del hero (GSAP ya maneja la rotación) — */
+.gano-monolith {
+    aspect-ratio: 2 / 3;
+    width: clamp(160px, 28vw, 320px);
+    background: linear-gradient(
+        180deg,
+        var(--gano-indigo-soft, rgba(99,102,241,0.10)) 0%,
+        var(--gano-purple-soft, rgba(139,92,246,0.10)) 100%
+    );
+    border: 1px solid var(--gano-border-sota, rgba(99,102,241,0.20));
+    border-radius: var(--gano-radius-lg, 16px);
+    backdrop-filter: blur(40px);
+    -webkit-backdrop-filter: blur(40px);
+    will-change: transform;
+    pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .gano-monolith {
+        animation: none !important;
+        transform: none !important;
+    }
+}
+
+/* END: HERO OVERLAY + DOMAIN SEARCH FIX */


### PR DESCRIPTION
## Problema

El hero de gano.digital tiene texto ilegible sobre la imagen de fondo (cerebro IA cyberpunk), y la sección de búsqueda de dominios tiene un fondo lavanda que rompe la paleta oscura de la marca.

## Solución

### 1. Overlay oscuro para el hero
- Nueva clase CSS `.gano-hero-overlay` → agrega un pseudo-elemento `::before` con gradiente oscuro (`#05080C` 88% → azul corporativo 25%) sobre cualquier imagen de fondo
- Aplica `isolation: isolate` para que el overlay no afecte otros stacking contexts
- El `.elementor-container` queda en `z-index: 2` sobre el overlay

### 2. Text-shadow fuerte
- `.gano-el-hero-readability` ahora tiene 3 capas de sombra (opacidades 92% / 75% / 98%) — legible sobre fondos oscuros **y** sobre imágenes con textura

### 3. Domain search — elimina lavanda
- `.gano-domain-section` fuerza `background-color: var(--gano-dark-deep)` con `!important`
- Selector `:has(.rstore-domain-search)` como respaldo automático
- Overrides en `.rstore-domain-search`: inputs con `--gano-card-sota`, CTA con `--gano-orange`

### 4. Monolith CSS
- `.gano-monolith`: figura geométrica lista para rotación GSAP — `backdrop-filter: blur(40px)`, gradiente `indigo-soft → purple-soft`, borde `--gano-border-sota`
- `prefers-reduced-motion`: desactiva animación completamente

## Instrucciones para Diego (Elementor)

| Elemento | Dónde | Clase a agregar |
|---|---|---|
| Sección hero | Avanzado → Clases CSS | `gano-hero-overlay` |
| Widget H1 del hero | Avanzado → Clases CSS | `gano-el-hero-readability` |
| Sección búsqueda de dominio | Avanzado → Clases CSS | `gano-domain-section` |

> Si el plugin carga el fondo lavanda por su cuenta (sin clase de Elementor), el selector `:has(.rstore-domain-search)` lo corrige automáticamente sin acción manual.

## Recomendación de imagen

La imagen actual (cerebro IA cyberpunk) debe reemplazarse. El brief completo de la imagen correcta está en `memory/content/art-direction-hero-2026.md`:
- Vista de rack de servidores, ángulo picado, luces LED azul-blanco, fondo oscuro
- Sin personas, sin logos de terceros
- Formato: 1920×1080px WebP < 200KB

## Test plan

- [ ] Agregar `gano-hero-overlay` a la sección hero en Elementor → verificar overlay visible
- [ ] Agregar `gano-el-hero-readability` al H1 → verificar texto legible sobre imagen
- [ ] Agregar `gano-domain-section` a la sección del buscador → fondo cambia a `#05080C`
- [ ] Sin la clase manual, verificar que `:has()` también resuelve el fondo lavanda
- [ ] Test `prefers-reduced-motion`: activar en macOS → `.gano-monolith` sin animación
- [ ] Mobile 375px: overlay no corta el texto
- [ ] WCAG AA: contrastar H1 sobre overlay oscuro → pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)