### PR TITLE
fix(gano-child): cursor WC3 fluido, filtro off y doc ops

### DIFF
--- a/memory/ops/gano-wc3-cursor-maintenance.md
+++ b/memory/ops/gano-wc3-cursor-maintenance.md
@@ -1,0 +1,100 @@
+# Cursor WC3 (guantelete) — mantenimiento, pruebas y mitigación
+
+**Contexto:** Cursor personalizado del tema hijo (`gano-child`) inspirado en *Warcraft III*, usando atlas raster `assets/cursor/wc3-human-atlas.png` (256×128) y lógica en `js/gano-cursor.js` + `css/gano-cursor.css`.
+
+**PRs de referencia:** [#274](https://github.com/Gano-digital/Pilot/pull/274) (feature), [#275](https://github.com/Gano-digital/Pilot/pull/275) (hover en iconos). Mejoras posteriores (animación, accesibilidad, filtro de apagado) van en commits posteriores a esta guía.
+
+---
+
+## 1. Archivos involucrados
+
+| Ruta | Rol |
+|------|-----|
+| `wp-content/themes/gano-child/assets/cursor/wc3-human-atlas.png` | Sprite atlas (idle fila superior, miras fila central, estados inferiores). |
+| `wp-content/themes/gano-child/css/gano-cursor.css` | `cursor: none` condicionado, posiciones de fondo por estado, breakpoints. |
+| `wp-content/themes/gano-child/js/gano-cursor.js` | Inserción del nodo, clases en `body`, `mousemove`, `mouseleave` en `documentElement`, click. |
+| `wp-content/themes/gano-child/functions.php` | `wp_enqueue_*` con `filemtime` y filtro `gano_enable_wc3_cursor`. |
+
+---
+
+## 2. Comportamiento esperado (checklist manual)
+
+En **Chrome/Edge** escritorio, `pointer: fine`:
+
+1. **Idle:** guantelete animado (8 fotogramas, `steps(7)` en CSS) siguiendo el puntero con ligero **lerp** (suavizado).
+2. **Sobre enlace/botón/CTA:** se detiene la animación idle y se muestra la **mira** (fila central del atlas, `background-position: 0 -32px`).
+3. **Sobre elemento deshabilitado** (`disabled`, `aria-disabled`, `.disabled`): mira **inválida** (`-64px -96px`).
+4. **Click:** pose alternativa (`-96px -96px`) + escala 0.92 hasta `mouseup`.
+5. **Campos de texto** (`input` texto, `textarea`, `contenteditable`): cursor del sistema tipo texto, overlay oculto.
+6. **`prefers-reduced-motion: reduce`:** el script **no** inicializa el cursor; el CSS fuerza `cursor: auto` y oculta el wrapper si existiera.
+7. **`pointer: coarse` o ancho ≤1024px:** sin cursor custom (CSS + early return en JS).
+
+**Consola:** no debe haber errores en cada paso.
+
+---
+
+## 3. Mitigación rápida (sin deploy de código)
+
+### Opción A — Filtro WordPress (recomendado)
+
+En un **MU-plugin**, `functions.php` del child (temporal), o plugin tipo “Code snippets”:
+
+```php
+add_filter( 'gano_enable_wc3_cursor', '__return_false' );
+```
+
+Esto omite el `wp_enqueue` del CSS/JS del cursor. Los visitantes recuperan el cursor nativo al refrescar (caché de página puede demorar 1 ciclo CDN).
+
+### Opción B — Quitar atlas
+
+Si el problema es solo el PNG (404, peso, licencia): dejar el filtro en `false` o borrar `wc3-human-atlas.png` y **comentar** los `enqueue` en `functions.php` hasta sustituir el asset.
+
+---
+
+## 4. Rollback completo (volver al estado “sin WC3”)
+
+1. Aplicar **Opción A** o revertir en Git el commit del cursor (tema hijo).
+2. Opcional: eliminar `assets/cursor/wc3-human-atlas.png` y los archivos `gano-cursor.*` si se retira la feature por completo.
+3. Desplegar con el flujo habitual (`main` → workflow **04 · Deploy** si aplica).
+
+---
+
+## 5. Conflictos típicos con otro código
+
+| Síntoma | Causa probable | Acción |
+|---------|----------------|--------|
+| Cursor invisible pero clics OK | Otro `cursor: none` global o z-index encima del `.gano-cursor-gauntlet` | Inspeccionar capas; subir `z-index` del gauntlet o bajar overlay conflictivo. |
+| Doble cursor / parpadeo | Tema/plugin también inyecta cursor custom | Desactivar el otro componente o usar filtro `gano_enable_wc3_cursor` false. |
+| Hover “incorrecto” en iconos | Selector `hover` no coincide con el DOM (Elementor, `role` raro) | Ampliar `hoverSelector` en `gano-cursor.js` o marcar nodos con `data-gano-cursor-hover`. |
+| Animación entrecortada | CPU throttling o muchos `filter` en la página | Probar sin `drop-shadow` en `.gano-cursor-gauntlet` o reducir frecuencia del keyframe. |
+| Texto sin I-beam | `gano-cursor--text` no se aplica | Añadir el `type` de input faltante en `textCursorSelector`. |
+
+---
+
+## 6. Verificación en servidor (SSH)
+
+**No** fijar host/usuario en el repo: usar el alias o variables documentadas en sesiones internas (`GANO_SSH_HOST`, etc.).
+
+Ejemplos de comprobación **solo lectura** (ruta típica GoDaddy cPanel; ajustar si tu hosting usa otro layout):
+
+```bash
+BASE=public_html/gano.digital/wp-content/themes/gano-child
+ls -la "$BASE/js/gano-cursor.js" "$BASE/assets/cursor/wc3-human-atlas.png"
+wc -c "$BASE/js/gano-cursor.js"
+# Coherencia con el artefacto local tras git pull (opcional)
+md5sum "$BASE/js/gano-cursor.js"
+```
+
+Tras un deploy por webhook, el ZIP actualiza el tema; si los `md5` locales (tras `git pull`) y remotos coinciden, el sync es correcto.
+
+---
+
+## 7. Issues GitHub relacionados
+
+Los issues abiertos **#263–#265** son operativos (RCC, slugs, tablero); **no** bloquean el cursor. Si el cursor genera deuda (p. ej. A11y formal), abrir un issue con etiqueta `ux` enlazando a esta guía.
+
+---
+
+## 8. Legal / marca (recordatorio)
+
+El atlas reproduce iconografía de *Warcraft III*. Para uso comercial prolongado valorar **arte propio** o clearance; ver `memory/research/wc3-human-gauntlet-cursor-internet-extraction-2026-04.md`.

--- a/memory/research/wc3-human-gauntlet-cursor-internet-extraction-2026-04.md
+++ b/memory/research/wc3-human-gauntlet-cursor-internet-extraction-2026-04.md
@@ -1,0 +1,161 @@
+# WC3 — Cursor humano / guantelete: plan de extracción web y ejecución (2026-04)
+
+Documento único: **plan**, **fuentes**, **descargas ejecutadas**, **inventario local**, **mapeo a web/gano.digital** y **riesgos legales**.
+
+---
+
+## 1. Objetivo
+
+Recopilar desde internet la **información técnica** y **referencias visuales** necesarias para replicar o adaptar el cursor de **Humano (guantelete)** de *Warcraft III* e integrarlo después en **gano.digital**, preferentemente vía el patrón existente (`gano-cursor.js` + cursor DOM), no vía `cursor: url(*.ani)` (soporte web pobre).
+
+---
+
+## 2. Plan completo (fases)
+
+| Fase | Qué cubre | Criterio de hecho |
+|------|-------------|-------------------|
+| **A** | Documentación motor (MDX + BLP, secuencias, atlas) | Lista de animaciones y enlace al tutorial verificado |
+| **B** | Referencia de textura in-game (dimensiones atlas) | Medida confirmada (p. ej. 256×128) + URL de descarga PNG |
+| **C** | Cursores Windows (.cur / .ani) para prototipo / hotspots | ZIP comunitario con licencia declarada + extracción local |
+| **D** | Set alternativo “gauntlet” | Segundo ZIP para comparar variantes |
+| **E** | Manifest de integridad | `sources-manifest.json` con SHA-256 por archivo |
+| **F** | (Siguiente, no ejecutado aquí) | Convertir `.cur` → PNG/WebP, medir hotspot, sprite sheet + JSON para tema hijo |
+
+---
+
+## 3. Ejecución realizada (2026-04-19)
+
+### 3.1 Descargas binarias (completadas)
+
+| Origen | URL directa | Destino en repo |
+|--------|-------------|------------------|
+| RealWorld Cursor — *WARCRAFT 3 HUMAN* | https://www.rw-designer.com/cursor-downloadset/warcraft-3-human.zip | `memory/research/wc3-human-gauntlet-cursor-downloads/warcraft-3-human.zip` |
+| RealWorld Cursor — *GAUNTLET WARCRAFT 3* | https://www.rw-designer.com/cursor-downloadset/gauntlet-warcraft-3.zip | `memory/research/wc3-human-gauntlet-cursor-downloads/gauntlet-warcraft-3.zip` |
+| The Spriters Resource — atlas PNG | https://www.spriters-resource.com/media/assets/193/196317.png | `memory/research/wc3-human-gauntlet-cursor-downloads/spriters-human-cursor-atlas-196317.png` |
+
+Páginas de contexto (licencia “Release to Public Domain” según RW Designer en cada set):
+
+- https://www.rw-designer.com/cursor-set/warcraft-3-human  
+- https://www.rw-designer.com/cursor-set/gauntlet-warcraft-3  
+- https://www.rw-designer.com/licenses  
+
+### 3.2 Extracción ZIP
+
+- `warcraft-3-human.zip` → `memory/research/wc3-human-gauntlet-cursor-downloads/extracted-warcraft-3-human/`
+- `gauntlet-warcraft-3.zip` → `memory/research/wc3-human-gauntlet-cursor-downloads/extracted-gauntlet-warcraft-3/`
+
+### 3.3 Integridad
+
+- `memory/research/wc3-human-gauntlet-cursor-downloads/sources-manifest.json` — 29 entradas (archivos extraídos + ZIP + PNG + el propio manifest).  
+- **Nota:** si se regenera el manifest, conviene excluir `sources-manifest.json` del listado para evitar hash circular.
+
+---
+
+## 4. Información técnica clave (internet, verificada)
+
+### 4.1 Motor original del juego (MDX + BLP)
+
+- Modelo UI **`HumanCursor.mdx`**, textura **`HumanCursor.blp`**, **BlendTime** 150 (comunidad).  
+- **14 secuencias** documentadas en tutorial Hive: `Target`, `Normal`, `Select`, `TargetSelect`, `InvalidTarget`, `HoldItem`, ocho `Scroll *`.  
+- Fuente: [Creating a custom cursor | Hive Workshop](https://www.hiveworkshop.com/threads/creating-a-custom-cursor.134122/)
+
+### 4.2 Atlas raster (referencia de layout)
+
+- The Spriters Resource — asset **Cursor (Human)**, **256×128** px, PNG.  
+- Página: https://www.spriters-resource.com/pc_computer/warcraft3reignofchaos/sheet/196317/
+
+### 4.3 Cursores en navegador (contexto histórico vs SOTA)
+
+- RW Designer aún documenta `cursor: url(...)`; para producción moderna, preferir **cursor sintético** (como Gano ya hace) por limitaciones de `.ani` y GIF en CSS.  
+- https://www.rw-designer.com/cursors-online  
+
+---
+
+## 5. Inventario de archivos extraídos (nombres exactos)
+
+### 5.1 `extracted-warcraft-3-human/`
+
+| Archivo | Rol aproximado para web |
+|---------|-------------------------|
+| `Human.cur` | Puntero principal humano |
+| `move1.cur`, `attack1.cur` | Movimiento / acción |
+| `cursor_spell_default.ani`, `HU WIB.ani`, `HUMAN LINK.ani` | Hechizo, “what is buff”, enlace |
+| `UNAVABIBLE.ani` | No disponible (typo en nombre original) |
+| `War-*.cur` | Resize / beam / pen / move / no / cross / up — equivalentes a `cursor: *` del SO |
+| `readme.txt` | Autor **THTH**, licencia PD según archivo |
+| `warcraft-3-human.crs` | Metadatos RealWorld Cursor |
+
+### 5.2 `extracted-gauntlet-warcraft-3/`
+
+| Archivo | Rol aproximado |
+|---------|----------------|
+| `normal cursor.cur`, `link select.cur`, `wib.cur` | Variantes de puntero |
+| `busy.ani`, `text.ani` | Espera / texto I‑beam animado |
+| `readme.txt` | Autor **THTH**, licencia PD según archivo |
+
+---
+
+## 6. Mapeo sugerido → integración `gano-child`
+
+Código actual del cursor premium:
+
+- `wp-content/themes/gano-child/js/gano-cursor.js`
+- `wp-content/themes/gano-child/css/gano-cursor.css`
+
+Sugerencia de correspondencia (iteración futura):
+
+| Estado web (clase o flag) | Archivo de referencia RW | Analogía MDX (Hive) |
+|---------------------------|--------------------------|---------------------|
+| Idle | `Human.cur` / `normal cursor.cur` | `Normal` |
+| Hover CTA / enlace | `HUMAN LINK.ani` o anillo actual | `Target` / `TargetSelect` |
+| `mousedown` | frame de “cierre” o `attack1.cur` | `Select` |
+| `disabled` / zona no clicable | `UNAVABIBLE.ani` | `InvalidTarget` |
+| `wait` / loading | `cursor_spell_default.ani` o `busy.ani` | (no 1:1; UI propia) |
+| Resize ventana (si aplica) | `War-Size *.cur` | `Scroll *` (solo si implementás bordes) |
+
+Implementación recomendada: **sustituir dot/ring** por un `<div>` con `background-image` (sprite) o `<img>`, manteniendo **lerp** y **eventos** ya existentes.
+
+---
+
+## 7. Herramientas siguientes (fase F)
+
+1. **Extraer PNG desde `.cur` / frames desde `.ani`**: ImageMagick, Greenfish Icon Editor, o librerías Node (`to-ico` inverso limitado; a menudo mejor herramienta gráfica en Windows).  
+2. **Hotspot**: leer cabecera CUR (coordenadas del “click point”) y aplicar como `transform-origin` en CSS.  
+3. **Empaquetado web**: sprite sheet + `manifest.json` por estado (`fps`, `loop`, `offset`).  
+4. **Accesibilidad**: respetar `prefers-reduced-motion`; no forzar cursor custom en touch (ya alineado con `@media (pointer: fine)` en `gano-cursor.css`).
+
+---
+
+## 8. Aviso legal (obligatorio para gano.digital)
+
+- Los ZIP de RW Designer declaran **“Released to Public Domain”** en la página del set y en `readme.txt` (**autor THTH**). Eso cubre la **contribución del autor al sitio**, no sustituye automáticamente un **clearance comercial** frente a posibles reclamos de **derechos de autor / marca** sobre el diseño icónico del juego.  
+- El PNG de Spriters Resource es **rip de juego** con términos del sitio; úsalo como **referencia de proporción**, no como base final de marca comercial sin revisión legal.  
+- Para producción en **gano.digital**, lo más seguro sigue siendo **arte original inspirado** o **licencia explícita**.
+
+---
+
+## 9. Checklist rápido “¿está listo para integrar?”
+
+- [x] Atlas 256×128 descargado y referenciado  
+- [x] Sets `.cur`/`.ani` locales + hashes  
+- [ ] Conversión a assets web (PNG/WebP) + medición de hotspot  
+- [ ] Branch en tema hijo + feature flag (opcional)  
+- [ ] Revisión legal si el visual es demasiado cercano al oficial  
+
+---
+
+## 10. SHA-256 de los ZIP y del PNG (copia rápida)
+
+| Archivo | SHA-256 |
+|---------|---------|
+| `warcraft-3-human.zip` | `E856F404C53786B60C4623BAC799D4D61EFBD088C952B2EA4DF880E5C4D4A25B` |
+| `gauntlet-warcraft-3.zip` | `F16342D98C91FAB55B0308DEBAFB4CAD9F34C7C838070505CA817789207AA1A8` |
+| `spriters-human-cursor-atlas-196317.png` | `2DDE3B99B3BA0AC489ABB890461EEB892598A191EAD50ACD07CCAAE533868B8F` |
+
+*(Detalle completo: `sources-manifest.json` en la misma carpeta.)*
+
+---
+
+## 11. Mantenimiento en producción (post-implementación)
+
+Ver **`memory/ops/gano-wc3-cursor-maintenance.md`**: checklist de pruebas, filtro `gano_enable_wc3_cursor`, rollback y verificación SSH.

--- a/wp-content/themes/gano-child/css/gano-cursor.css
+++ b/wp-content/themes/gano-child/css/gano-cursor.css
@@ -1,6 +1,6 @@
-/* Gano — Cursor WC3 (guantelete): atlas 256×128, fila 0 = idle 8 fps, fila inferior = estados UI */
+/* Gano — Cursor WC3 (guantelete): atlas 256×128 — fila 0 idle, fila 1 miras, fila 3 estados / flechas */
 
-@media (pointer: fine) {
+@media (pointer: fine) and (prefers-reduced-motion: no-preference) {
     body:not(.gano-cursor--text),
     body:not(.gano-cursor--text) a,
     body:not(.gano-cursor--text) button,
@@ -16,6 +16,21 @@
     body.gano-cursor--text input,
     body.gano-cursor--text textarea {
         cursor: text !important;
+    }
+}
+
+@media (pointer: fine) and (prefers-reduced-motion: reduce) {
+    .gano-cursor-wrapper {
+        display: none !important;
+    }
+
+    body,
+    body a,
+    body button,
+    body [role='button'],
+    body label,
+    body select {
+        cursor: auto !important;
     }
 }
 
@@ -63,16 +78,12 @@ body.gano-cursor--text .gano-cursor-wrapper {
     }
 }
 
-body.gano-cursor--nomotion .gano-cursor-gauntlet {
-    animation: none;
-    background-position: 0 0;
-}
-
+/* Hover: fila central del atlas = mira (lectura “clicable”), no la celda inferior que era otro icono */
 body.gano-cursor--hover:not(.gano-cursor--invalid):not(.gano-cursor--click) .gano-cursor-gauntlet {
     --gano-cursor-hx: 16px;
     --gano-cursor-hy: 16px;
     animation: none;
-    background-position: -32px -96px;
+    background-position: 0 -32px;
 }
 
 body.gano-cursor--invalid .gano-cursor-gauntlet {
@@ -82,20 +93,26 @@ body.gano-cursor--invalid .gano-cursor-gauntlet {
     background-position: -64px -96px;
 }
 
+/* Click: guantelete en pose distinta (fila inferior), no otro frame idéntico de la fila 0 */
 body.gano-cursor--click:not(.gano-cursor--invalid) .gano-cursor-gauntlet {
+    --gano-cursor-hx: 16px;
+    --gano-cursor-hy: 16px;
     animation: none;
-    background-position: -128px 0;
+    background-position: -96px -96px;
     transform: translate(calc(-1 * var(--gano-cursor-hx)), calc(-1 * var(--gano-cursor-hy))) scale(0.92);
 }
 
 @media (max-width: 1024px) {
     .gano-cursor-wrapper {
-        display: none;
+        display: none !important;
     }
 
     body,
-    a,
-    button {
+    body a,
+    body button,
+    body [role='button'],
+    body label,
+    body select {
         cursor: auto !important;
     }
 }

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -149,22 +149,24 @@ function gano_child_enqueue_styles() {
     wp_enqueue_style( 'gano-quiz-css', get_stylesheet_directory_uri() . '/css/gano-quiz.css', array(), '1.0.0' );
     wp_enqueue_script( 'gano-quiz-js', get_stylesheet_directory_uri() . '/js/gano-sovereignty-quiz.js', array(), '1.0.0', true );
 
-    // Custom Cursor — WC3 guantelete (atlas en assets/cursor)
-    $gano_cursor_css = get_stylesheet_directory() . '/css/gano-cursor.css';
-    $gano_cursor_js  = get_stylesheet_directory() . '/js/gano-cursor.js';
-    wp_enqueue_style(
-        'gano-cursor-style',
-        get_stylesheet_directory_uri() . '/css/gano-cursor.css',
-        array(),
-        file_exists( $gano_cursor_css ) ? (string) filemtime( $gano_cursor_css ) : '2.0.0'
-    );
-    wp_enqueue_script(
-        'gano-cursor-js',
-        get_stylesheet_directory_uri() . '/js/gano-cursor.js',
-        array(),
-        file_exists( $gano_cursor_js ) ? (string) filemtime( $gano_cursor_js ) : '2.0.0',
-        true
-    );
+    // Custom Cursor — WC3 guantelete (atlas en assets/cursor). Mitigar: add_filter( 'gano_enable_wc3_cursor', '__return_false' ); (MU-plugin o snippets).
+    if ( apply_filters( 'gano_enable_wc3_cursor', true ) ) {
+        $gano_cursor_css = get_stylesheet_directory() . '/css/gano-cursor.css';
+        $gano_cursor_js  = get_stylesheet_directory() . '/js/gano-cursor.js';
+        wp_enqueue_style(
+            'gano-cursor-style',
+            get_stylesheet_directory_uri() . '/css/gano-cursor.css',
+            array(),
+            file_exists( $gano_cursor_css ) ? (string) filemtime( $gano_cursor_css ) : '2.0.0'
+        );
+        wp_enqueue_script(
+            'gano-cursor-js',
+            get_stylesheet_directory_uri() . '/js/gano-cursor.js',
+            array(),
+            file_exists( $gano_cursor_js ) ? (string) filemtime( $gano_cursor_js ) : '2.0.0',
+            true
+        );
+    }
 
     // GSAP 3 Core & Plugins — Solo en páginas que lo necesitan (Phase 5 - SOTA Animation)
     $needs_gsap = is_page_template( 'templates/page-sota-hub.php' )

--- a/wp-content/themes/gano-child/js/gano-cursor.js
+++ b/wp-content/themes/gano-child/js/gano-cursor.js
@@ -4,6 +4,12 @@
  */
 
 document.addEventListener('DOMContentLoaded', function () {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const finePointer = window.matchMedia('(pointer: fine)').matches;
+    if (reduceMotion || !finePointer) {
+        return;
+    }
+
     const wrapper = document.createElement('div');
     wrapper.className = 'gano-cursor-wrapper';
     wrapper.innerHTML = '<div id="gano-cursor-gauntlet" class="gano-cursor-gauntlet" aria-hidden="true"></div>';
@@ -18,15 +24,10 @@ document.addEventListener('DOMContentLoaded', function () {
     let mouseY = 0;
     let drawX = 0;
     let drawY = 0;
-    const lerpFollow = 1;
-
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (reduceMotion) {
-        document.body.classList.add('gano-cursor--nomotion');
-    }
+    const lerpFollow = 0.22;
 
     const hoverSelector =
-        'a[href], button, [role="button"], [role="link"], label, select, i, .gano-quiz-option, input[type="submit"], .rstore-add-to-cart, summary, [data-gano-cursor-hover]';
+        'a[href], button, [role="button"], [role="link"], label, select, .gano-quiz-option, input[type="submit"], input[type="button"], input[type="reset"], .rstore-add-to-cart, summary, [data-gano-cursor-hover], a[href] i, button i, [role="button"] i';
 
     const textCursorSelector =
         'input[type="text"], input[type="email"], input[type="search"], input[type="url"], input[type="tel"], input[type="password"], input[type="number"], textarea, [contenteditable="true"]';
@@ -43,12 +44,18 @@ document.addEventListener('DOMContentLoaded', function () {
         mouseY = e.clientY;
 
         const t = e.target instanceof Element ? e.target : null;
-        document.body.classList.toggle('gano-cursor--text', !!targetMatches(t, textCursorSelector));
-        document.body.classList.toggle('gano-cursor--invalid', !!targetMatches(t, invalidSelector));
+        const onText = !!targetMatches(t, textCursorSelector);
+        const onInvalid = !!targetMatches(t, invalidSelector);
+        document.body.classList.toggle('gano-cursor--text', onText);
+        document.body.classList.toggle('gano-cursor--invalid', onInvalid);
         document.body.classList.toggle(
             'gano-cursor--hover',
-            !!targetMatches(t, hoverSelector) && !targetMatches(t, invalidSelector)
+            !onText && !!targetMatches(t, hoverSelector) && !onInvalid
         );
+    });
+
+    document.documentElement.addEventListener('mouseleave', function () {
+        document.body.classList.remove('gano-cursor--hover', 'gano-cursor--click', 'gano-cursor--invalid', 'gano-cursor--text');
     });
 
     function animate() {


### PR DESCRIPTION
## Resumen
- Cursor WC3: lerp suave, early exit si \pointer: coarse\ o \prefers-reduced-motion\, hover sin pisar modo texto, reset al salir del documento, iconos bajo \\/\utton\.
- CSS: \cursor: none\ solo con \prefers-reduced-motion: no-preference\, atlas hover (mira) y click corregidos, mobile \!important\.
- PHP: filtro \gano_enable_wc3_cursor\ (default true) para mitigar sin borrar código.
- Docs: \memory/ops/gano-wc3-cursor-maintenance.md\ + enlace desde investigacion atlas.

## Issues
Sin cambios en #263-#265 (ops); esta PR es UX cursor aislado.

## Pruebas
- \php -l\ functions.php OK
- SSH produccion: archivos presentes bajo \public_html/gano.digital/...\ (pre-deploy); tras merge verificar \wc -c\ vs local.


Made with [Cursor](https://cursor.com)