### PR TITLE
fix(mu-plugins): allowlist REST lead-capture (lead magnet)

### DIFF
--- a/wp-content/mu-plugins/gano-security.php
+++ b/wp-content/mu-plugins/gano-security.php
@@ -285,6 +285,8 @@ add_filter( 'rest_authentication_errors', function( $result ) {
         // Las rutas están aquí como respaldo; el nonce es la verificación real.
         '/wp-json/gano-agent/v1/log',
         '/wp-json/gano/v1/chat',
+        // Lead magnet homepage — POST con nonce verificado en el callback del tema.
+        '/wp-json/gano/v1/lead-capture',
     ];
 
     foreach ( $allowed_rest as $allowed ) {


### PR DESCRIPTION
## Descripcion
El filtro \est_authentication_errors\ en \gano-security.php\ bloqueaba la REST API para usuarios no autenticados salvo rutas en lista blanca. El lead magnet de la homepage hace POST a \/wp-json/gano/v1/lead-capture\ con nonce validado en el tema; sin esta entrada respondia **401**.

## Cambios
- \wp-content/mu-plugins/gano-security.php\: añade \/wp-json/gano/v1/lead-capture\ a \\\.

## Tipo
- Bug fix / seguridad (superficie REST acotada; el callback del tema sigue exigiendo nonce y rate limit).

## Testing sugerido
1. Desde la home, enviar el formulario de guia con email valido → **200** y lead en wp-admin → Leads.
2. Comprobar que otros endpoints REST anonimos no deseados siguen bloqueados.

Ref #264