### PR TITLE
feat(gano-child): Atlas home, catálogo COP/USD, landing limpio, guía checkout

### DIFF
--- a/memory/ops/auditoria-ssh-inventario-navegacion-home-2026-04-22.md
+++ b/memory/ops/auditoria-ssh-inventario-navegacion-home-2026-04-22.md
@@ -1,0 +1,133 @@
+# Auditoría SSH — inventario de contenido, navegación y alineación repo/servidor
+
+**Fecha:** 2026-04-22 · **Sitio:** `gano.digital` (docroot WP vía SSH/WP-CLI).  
+**Objetivo:** inventario de páginas/entradas visibles, menús, brecha con repo, acciones (borradores publicados), hallazgos críticos y **especificación** del índice animado del hero (implementación tras aprobación + respuestas al cuestionario).
+
+---
+
+## 1. Resumen ejecutivo
+
+| Hallazgo | Severidad |
+|----------|-----------|
+| La **home** (`page_on_front` **1745** *Inicio*) está construida en **Elementor**, no con `front-page.php` del child theme. | **Alta** para alineación repo ↔ producción: el hero “animado” del repo no se ve en vivo hasta cambiar plantilla o portar diseño a Elementor/bloque. |
+| Menú **Menú Principal** (ubicación `primary`): **9 enlaces**; muchas páginas publicadas (pilares SOTA, blog, catálogo, **comenzar-aqui**, **shop-premium**) **no** están en el menú. | **Alta** UX — contenido huérfano. |
+| Páginas **Woo legacy** (`/shop/`, `/cart/`, `/checkout/`, `/my-account/`) siguen publicadas. | **Media** — confusión si Woo no está en uso comercial. |
+| **Borradores de página** masivos: publicados en bloque (excl. `1698` Coming Soon, `1752`/`1753` Ecosistemas duplicados, `1815` Dashboard demo duplicado). | **Hecho** — revisar SEO canibalización y calidad. |
+| **Posts** en inglés legacy (IDs 620–625) coexisten con posts ES nuevos. | **Media** editorial. |
+
+---
+
+## 2. Alineación servidor ↔ repo
+
+| Aspecto | Servidor | Repo (`gano-child`) |
+|---------|----------|---------------------|
+| Tema activo | `gano-child` **1.0.6** | `style.css` Version 1.0.6 |
+| Home | Página **1745** slug `inicio`, **Elementor** (`_elementor_edit_mode` = builder). `_wp_page_template` no forzó `front-page.php` en la consulta previa. | `front-page.php` define hero SOTA PHP + secciones (`#ecosistemas`, dominio, etc.). |
+| Templates PHP | Asignados en páginas SOTA (1754–1757, 1656, etc. según despliegues previos) | `templates/*.php` — verificar `_wp_page_template` por página en próxima pasada WP-CLI si hace falta. |
+
+**Conclusión:** el “diseño canónico” del repo para home **no es** el que renderiza WordPress hoy; cualquier **índice animado en hero** debe implementarse **donde vive la home real** (Elementor + CSS global, **o** migrar la home a `front-page.php` con decisión explícita).
+
+---
+
+## 3. Lectura de sitio (WP-CLI)
+
+- `show_on_front`: **page** · `page_on_front`: **1745**
+- Permalinks: **`/%postname%/`**
+- Menús:
+  - **`menu-principal`** (term_id **104**): `primary`, `header`, `main` — **10** ítems en listado meta (9 visibles en export: Inicio, Nosotros, Dominios, Hosting, Servicios, Ecosistemas, SOTA Hub, Diagnóstico, Contacto).
+  - **`legal-footer-menu`** (105): privacidad, términos, cookies.
+  - **`main-menu`** (4): ítems legacy (`Hosting` → `#`, Servicios → `?page_id=1594`).
+
+---
+
+## 4. Inventario — páginas publicadas (muestra estructural)
+
+Pilares SOTA (ejemplos IDs **1766–1778**): Blog, Diagnóstico, SEO, SOTA Hub, Shop (`shop-premium`), Ecosistemas, pilares técnicos (`seguridad-zero-trust`, `almacenamiento-nvme`, …), `arquitectura-cloud`, `catalogo-sota`, `comenzar-aqui`, `dashboard-demo-2`, etc.
+
+Legales y confianza: contacto, soporte, nosotros, dominios, hosting, servicios, políticas.
+
+**Ausentes del menú principal (ejemplos):** `/shop-premium/`, `/comenzar-aqui/`, `/blog/`, `/catalogo-sota/`, pilares 1767–1774, artículos legales ya en footer.
+
+---
+
+## 5. Inventario — entradas (`post`)
+
+Publicados (muestra): **1779–1781** (ES, temas soberanía/NVMe/zero-trust), **1675–1677** (guías ES), **620–625** (EN, guías genéricas hosting).
+
+---
+
+## 6. Borradores → publicados (acción 2026-04-22)
+
+Publicadas **todas** las páginas en estado `draft` **excepto**:
+
+- **1698** — Coming Soon  
+- **1752**, **1753** — *Ecosistemas* duplicados  
+- **1815** — *Dashboard SOTA Demo* (borrador; existe **1816** publicado *dashboard-demo-2*)
+
+**Riesgo:** muchas URLs nuevas indexables; posible **solapamiento temático** con pilares ya publicados (NVMe, zero-trust, etc.). Recomendación: auditoría editorial + `noindex` o fusión donde aplique.
+
+---
+
+## 7. Evaluación crítica (contenido + UX)
+
+1. **Dos “voces” y dos idiomas** en blog (EN 620–625 vs ES reciente) — inconsistente para Colombia.  
+2. **Categorización ausente** en menú: el visitante no descubre el catálogo de artículos salvo Google o enlaces internos.  
+3. **Hero actual (Elementor)** no articula profundidad del archivo publicado.  
+4. **main-menu** con `#` y `page_id` antiguo — deuda técnica de menú.  
+5. **LCP / animación:** cualquier índice animado en hero debe respetar `prefers-reduced-motion` y no competir con LCP del hero principal (skill UI/UX Pro Max — tokens `--gano-*`, sin wall-of-links).
+
+---
+
+## 8. Paleta y tokens (para el índice animado — especificación previa a código)
+
+Fuente: `wp-content/themes/gano-child/style.css` (`:root`).
+
+- **Acento / foco:** `--gano-gold` `#D4AF37`, `--gano-gold-border`, `--gano-gold-soft`  
+- **Primario:** `--gano-blue` / `--gano-color-primary`  
+- **CTA energía:** `--gano-orange`  
+- **Superficie oscura:** `--gano-bg-dark`, `--gano-dark`, texto `--gano-color-text-on-dark`  
+- **Radio / transición:** `var(--gano-radius-*)`, `var(--gano-transition)`
+
+**Anti-patrones:** más de ~8 nodos visibles a la vez en mobile; animación continua sin pausa; enlaces sin `focus-visible`.
+
+---
+
+## 9. Propuesta de diseño — “Atlas de lectura” (hero / primera vista)
+
+**Concepto:** panel compacto bajo el CTA del hero (o botón “Explorar archivo”) que abre una **superficie glass** (`backdrop-filter`, borde `--gano-gold-border`) con:
+
+1. **Chips** de filtro: *Todos · Pilares SOTA · Guías · Legal* (taxonomía o `post_type` acordada).  
+2. **Lista animada** (stagger `opacity` + `translateY` 8px, **max 400 ms**, `prefers-reduced-motion: reduce` → sin stagger).  
+3. Cada ítem: título, etiqueta de tipo, enlace a URL canónica.
+
+**Variantes de implementación (tras aprobación):**
+
+| Opción | Pros | Contras |
+|--------|------|---------|
+| **A.** Bloque HTML + CSS en Elementor + pequeño `gano-homepage.js` para filtros | Coherente con home actual | Requiere pegado en Elementor |
+| **B.** Cambiar home a `front-page.php` e incrustar componente PHP | Control total en repo | Cambio disruptivo de marketing/SEO |
+| **C.** Widget área + shortcode `[gano_content_atlas]` | Reutilizable | Requiere registrar shortcode en `functions.php` |
+
+**Motor de datos:** WP_Query `post_type=page,post`, `post_status=publish`, exclusiones opcionales (Woo, Coming Soon), orden por `modified` o menú manual vía opción/theme mod.
+
+---
+
+## 10. Investigación para enriquecer textos (fuentes internas)
+
+- `memory/content/homepage-copy-2026-04.md`, `homepage-sota-blueprint-2026-04-17.md`  
+- `memory/content/trust-pages-bundle-2026.md` (tono y claims verificables)  
+- `memory/ops/homepage-vitrina-launch-plan-2026-04.md` (RACI y fases)  
+- Skill **UI/UX Pro Max:** motor opcional en `external/ui-ux-pro-max-skill` (no presente en workspace; clonar con `gh repo clone nextlevelbuilder/ui-ux-pro-max-skill external/ui-ux-pro-max-skill` antes de generar design system asistido).
+
+---
+
+## 11. Ejecución post-aprobación (2026-04-22)
+
+1. **Código en repo:** shortcode `[gano_content_atlas]`, `inc/gano-content-atlas.php`, `css/gano-content-atlas.css`, `js/gano-content-atlas.js`, hero en `front-page.php`, enqueue en `functions.php`.  
+2. **Runbook Elementor:** [`runbook-elementor-atlas-home-2026-04-22.md`](runbook-elementor-atlas-home-2026-04-22.md) — pegar shortcode en la home 1745.  
+3. **Menú `menu-principal` (104):** añadidos **Blog** y **Comenzar aquí**; menú legacy **ID 4** eliminado.  
+4. **SEO:** pendiente auditoría editorial (canibalización) según respuesta cuestionario.
+
+---
+
+**Generado por:** auditoría agente Cursor + WP-CLI remoto.

--- a/memory/ops/runbook-elementor-atlas-home-2026-04-22.md
+++ b/memory/ops/runbook-elementor-atlas-home-2026-04-22.md
@@ -1,0 +1,61 @@
+# Runbook — Atlas de lectura en home Elementor (página 1745 *Inicio*)
+
+**Contexto:** En producción la home usa **Elementor**, no `front-page.php`. El Atlas ya está en código (`[gano_content_atlas]` + assets); para verlo en la home **sin** cambiar la página estática a plantilla PHP, pegá el shortcode en Elementor.
+
+---
+
+## 1. Pasos en wp-admin (Elementor)
+
+1. **Páginas → Inicio → Editar con Elementor** (ID típico 1745).
+2. Localizá la sección que reemplaza el antiguo bloque “Marco operativo / SLA” (o el bloque donde quieras el copy SOTA).
+3. Añadí widget **Código corto** (Shortcode).
+4. Pegá exactamente:
+   ```
+   [gano_content_atlas]
+   ```
+5. **Actualizar** la página.
+6. Visitá la home en incógnito: deberías ver el bloque **SOTA — State of the Art**, el botón **Mapa de lectura** y el enlace al catálogo SOTA.
+
+**Nota:** Si dejás la sección antigua duplicada, borrá el widget viejo para no repetir contenido.
+
+---
+
+## 2. Si preferís usar solo `front-page.php` del tema
+
+1. **Ajustes → Lectura**: mantener “Una página estática” pero editar la página Inicio.
+2. En la página Inicio, panel lateral **Atributos de página → Plantilla**: elegir **Gano Digital — Homepage** (si está registrada) o desactivar Elementor en esa página.
+3. Guardar. Entonces WordPress usará `front-page.php` del child (ya incluye el Atlas en el hero).
+
+---
+
+## 3. Menú principal (ya aplicable vía WP-CLI en servidor)
+
+Ítems añadidos según plan: **Blog** → `/blog/`, **Comenzar aquí** → `/comenzar-aqui/` en el menú `menu-principal` (ubicación primary).
+
+Menú legacy **main-menu** (ID 4): eliminado si ya no se usaba.
+
+---
+
+## 4. Curación del Atlas
+
+- Lista por defecto: slugs en `gano_atlas_default_curated_slugs()` en `inc/gano-content-atlas.php`.
+- **Extra / override:** opción `gano_atlas_curated_slugs` (texto): slugs separados por comas.
+  ```bash
+  wp option update gano_atlas_curated_slugs "slug-extra-1,slug-extra-2"
+  ```
+
+---
+
+## 5. Posts EN legacy (traducción)
+
+Plan editorial: traducir o reemplazar entradas 620–625; hasta entonces pueden quedar publicadas pero **fuera** del Atlas (no están en la lista curada).
+
+---
+
+## 6. QA rápido UX
+
+- [ ] Botón “Mapa de lectura” abre hoja inferior en móvil.
+- [ ] Chips filtran (Todos / Pilares / Guías / Legal).
+- [ ] Escape cierra; foco vuelve al botón.
+- [ ] `prefers-reduced-motion`: lista sin animación escalonada.
+- [ ] Sin errores de consola.

--- a/wp-content/themes/gano-child/css/catalog-sota.css
+++ b/wp-content/themes/gano-child/css/catalog-sota.css
@@ -58,9 +58,9 @@ h1,h2,h3,h4{font-family:var(--font-display);font-weight:700;line-height:1.2}
 .filter-inner{display:flex;flex-direction:column;gap:10px}
 .filter-row-top{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
 .filter-tabs{display:flex;gap:6px;flex-wrap:wrap}
-.ftab{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:var(--radius-md);font-family:var(--font-display);font-size:13px;font-weight:500;cursor:pointer;transition:var(--transition);border:1px solid var(--gano-border);background:var(--gano-surface);color:var(--gano-text-secondary);white-space:nowrap;user-select:none}
-.ftab:hover{border-color:rgba(27,79,216,0.4);color:var(--gano-text-primary)}
-.ftab.active{background:var(--gano-blue);border-color:var(--gano-blue);color:#fff;box-shadow:0 0 16px var(--gano-blue-glow)}
+.ftab{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:999px;font-family:var(--font-display);font-size:12px;font-weight:600;cursor:pointer;transition:var(--transition);border:1px solid rgba(70,69,84,0.35);background:rgba(45,52,73,0.4);color:var(--gano-text-secondary);white-space:nowrap;user-select:none}
+.ftab:hover{border-color:rgba(192,193,255,0.35);color:var(--gano-text-primary);background:rgba(192,193,255,0.08)}
+.ftab.active{background:linear-gradient(135deg,#c0c1ff,#8083ff);border-color:transparent;color:#1000a9;box-shadow:0 0 20px rgba(128,131,255,0.35)}
 .ftab i{font-size:11px}
 .price-toggle-wrap{display:flex;align-items:center;gap:10px;background:var(--gano-surface);border:1px solid var(--gano-border);border-radius:var(--radius-md);padding:7px 12px;flex-shrink:0}
 .ptl{font-family:var(--font-display);font-size:12px;font-weight:600;color:var(--gano-text-muted);transition:var(--transition)}
@@ -75,9 +75,9 @@ h1,h2,h3,h4{font-family:var(--font-display);font-weight:700;line-height:1.2}
 .obj-row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .obj-label{font-size:11px;font-weight:600;color:var(--gano-text-muted);text-transform:uppercase;letter-spacing:0.07em;white-space:nowrap}
 .obj-chips{display:flex;gap:6px;flex-wrap:wrap}
-.ochip{display:inline-flex;align-items:center;gap:5px;padding:5px 12px;border-radius:100px;font-size:12px;font-weight:600;cursor:pointer;transition:var(--transition);border:1px solid var(--gano-border);background:transparent;color:var(--gano-text-muted);user-select:none;font-family:var(--font-display)}
-.ochip:hover{border-color:rgba(27,79,216,0.4);color:var(--gano-text-secondary)}
-.ochip.active{background:rgba(27,79,216,0.15);border-color:rgba(27,79,216,0.5);color:#7BA7FF}
+.ochip{display:inline-flex;align-items:center;gap:5px;padding:6px 12px;border-radius:999px;font-size:11px;font-weight:600;cursor:pointer;transition:var(--transition);border:1px solid rgba(70,69,84,0.35);background:transparent;color:var(--gano-text-muted);user-select:none;font-family:var(--font-display)}
+.ochip:hover{border-color:rgba(76,215,246,0.35);color:var(--gano-text-secondary)}
+.ochip.active{background:rgba(192,193,255,0.14);border-color:rgba(192,193,255,0.45);color:#e2e8f0;box-shadow:0 0 14px rgba(76,215,246,0.12)}
 .ochip i{font-size:10px}
 .results-bar{display:flex;align-items:center;justify-content:space-between;padding:10px 0 0;border-top:1px solid var(--gano-border);margin-top:4px}
 .rcount{font-size:13px;color:var(--gano-text-muted)}
@@ -119,12 +119,22 @@ h1,h2,h3,h4{font-family:var(--font-display);font-weight:700;line-height:1.2}
 .card-tagline{font-size:13px;color:var(--gano-text-secondary);line-height:1.5}
 
 /* price */
-.card-price{display:flex;align-items:flex-end;gap:8px;flex-wrap:wrap;min-height:46px}
+.card-price{display:flex;flex-direction:column;align-items:flex-start;gap:6px;flex-wrap:wrap;min-height:52px;width:100%}
+.price-dual{display:flex;flex-direction:column;gap:2px;width:100%}
+.price-dual__row{display:flex;align-items:baseline;flex-wrap:wrap;gap:6px}
+.price-dual__primary .price-cop{font-family:var(--font-display);font-size:clamp(1.15rem,2.4vw,1.65rem);font-weight:700;letter-spacing:-0.02em;line-height:1.1;color:var(--gano-text-primary)}
+.price-dual__secondary .price-usd-ref{font-size:12px;font-weight:600;color:var(--gano-blue-light);letter-spacing:0.02em}
+.price-per{font-size:11px;color:var(--gano-text-muted);margin-bottom:0;text-transform:lowercase}
+.price-per--muted{opacity:0.85}
+.price-strike-dual{display:flex;flex-direction:column;gap:1px;font-size:12px;color:var(--gano-text-muted);text-decoration:line-through;margin-bottom:4px;opacity:0.9}
+.price-strike-sub{font-size:10px;margin-left:3px;text-decoration:line-through}
+.price-strike-usd{font-size:11px}
+.price-save{font-size:10px;font-weight:700;color:var(--gano-green);background:rgba(16,185,129,0.1);padding:3px 8px;border-radius:100px;margin-top:2px;align-self:flex-start;line-height:1.35}
+.price-save-usd{font-weight:600;opacity:0.95}
 .price-val{font-family:var(--font-display);font-size:30px;font-weight:700;letter-spacing:-0.03em;line-height:1;color:var(--gano-text-primary)}
-.price-per{font-size:12px;color:var(--gano-text-muted);margin-bottom:4px}
 .price-strike{font-size:13px;color:var(--gano-text-muted);text-decoration:line-through;margin-bottom:5px}
-.price-save{font-size:10px;font-weight:700;color:var(--gano-green);background:rgba(16,185,129,0.1);padding:2px 7px;border-radius:100px;align-self:flex-end;margin-bottom:4px}
 .price-custom{font-family:var(--font-display);font-size:18px;font-weight:600;color:var(--gano-text-secondary)}
+.catalog-price-disclaimer{font-size:11px;line-height:1.45;color:var(--gano-text-muted);margin:10px 0 0;max-width:720px;opacity:0.92}
 
 /* features */
 .feat-list{list-style:none;display:flex;flex-direction:column;gap:0}

--- a/wp-content/themes/gano-child/css/catalog-sota.css
+++ b/wp-content/themes/gano-child/css/catalog-sota.css
@@ -87,6 +87,12 @@ h1,h2,h3,h4{font-family:var(--font-display);font-weight:700;line-height:1.2}
 .catalog-grid-wrap{padding:0 0 96px}
 .no-results{text-align:center;padding:64px 0;color:var(--gano-text-muted);font-size:15px}
 .product-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:20px}
+.gano-cat-header{grid-column:1/-1;display:flex;align-items:center;gap:10px;padding:10px 0 6px;margin-top:8px;border-bottom:1px solid var(--gano-border)}
+.gano-cat-header:first-child{margin-top:0}
+.gano-cat-header-icon{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;background:rgba(192,193,255,0.1);border:1px solid rgba(192,193,255,0.22);color:#c0c1ff;font-size:15px;flex-shrink:0}
+.gano-cat-header-name{font-family:var(--font-display);font-weight:800;font-size:1rem;color:var(--gano-text-primary);letter-spacing:-0.02em}
+.gano-cat-header-count{font-size:11px;color:var(--gano-text-muted);background:rgba(70,69,84,0.35);padding:3px 10px;border-radius:999px;margin-left:auto;font-weight:600}
+.gano-cat-header--empty{display:none}
 .pcard{background:var(--gano-surface);border:1px solid var(--gano-border);border-radius:var(--radius-xl);padding:26px;display:flex;flex-direction:column;gap:18px;transition:var(--transition);position:relative;overflow:hidden}
 .pcard::after{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent,rgba(27,79,216,0.5),transparent);opacity:0;transition:var(--transition)}
 .pcard:hover{border-color:rgba(27,79,216,0.3);transform:translateY(-4px);box-shadow:var(--shadow-card)}

--- a/wp-content/themes/gano-child/css/gano-content-atlas.css
+++ b/wp-content/themes/gano-child/css/gano-content-atlas.css
@@ -1,0 +1,240 @@
+/**
+ * Atlas de lectura — tokens gano-child (UI/UX Pro Max: contraste, reduced-motion).
+ */
+
+.gano-atlas-hero {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 1.25rem;
+	margin-top: 1.5rem;
+	padding: 1.25rem 1.5rem;
+	background: linear-gradient(135deg, var(--gano-gold-soft, rgba(212, 175, 55, 0.1)), rgba(15, 25, 35, 0.35));
+	border: 1px solid var(--gano-gold-border, rgba(212, 175, 55, 0.3));
+	border-radius: var(--gano-radius-lg, 16px);
+	backdrop-filter: blur(12px);
+}
+
+@media (min-width: 768px) {
+	.gano-atlas-hero {
+		grid-template-columns: 1.4fr 1fr;
+		align-items: center;
+	}
+}
+
+.gano-atlas-hero__eyebrow {
+	margin: 0 0 0.35rem;
+	font-size: 0.75rem;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--gano-gold, #d4af37);
+}
+
+.gano-atlas-hero__copy {
+	margin: 0;
+	font-size: 0.95rem;
+	line-height: 1.55;
+	color: var(--gano-color-text-on-dark, #e2e8f0);
+}
+
+.gano-atlas-hero__action {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	align-items: flex-start;
+}
+
+.gano-atlas-open.btn-holo {
+	margin: 0;
+}
+
+.gano-atlas-hero__hint {
+	margin: 0;
+	font-size: 0.85rem;
+}
+
+.gano-atlas-hero__hint a {
+	color: var(--gano-gold, #d4af37);
+	text-decoration: underline;
+	text-underline-offset: 3px;
+}
+
+.gano-atlas-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 9998;
+	background: rgba(15, 25, 35, 0.55);
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.22s ease;
+}
+
+.gano-atlas-backdrop.is-visible {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.gano-atlas-sheet {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 9999;
+	max-height: 88vh;
+	display: flex;
+	flex-direction: column;
+	background: var(--gano-bg-dark, #0f1923);
+	border-radius: 1rem 1rem 0 0;
+	border: 1px solid var(--gano-gold-border, rgba(212, 175, 55, 0.3));
+	border-bottom: none;
+	box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.35);
+	transform: translateY(100%);
+	transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.gano-atlas-sheet.is-open {
+	transform: translateY(0);
+}
+
+.gano-atlas-sheet__head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 1rem 1.25rem;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.gano-atlas-sheet__title {
+	margin: 0;
+	font-size: 1.1rem;
+	color: var(--gano-white, #fff);
+}
+
+.gano-atlas-close {
+	background: transparent;
+	border: none;
+	color: var(--gano-gray-300, #d1d5db);
+	font-size: 1.75rem;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0.25rem 0.5rem;
+	border-radius: var(--gano-radius-md, 8px);
+}
+
+.gano-atlas-close:hover,
+.gano-atlas-close:focus-visible {
+	color: var(--gano-gold, #d4af37);
+	outline: 2px solid var(--gano-gold, #d4af37);
+	outline-offset: 2px;
+}
+
+.gano-atlas-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	padding: 0.75rem 1.25rem;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.gano-atlas-chip {
+	padding: 0.35rem 0.85rem;
+	border-radius: 999px;
+	border: 1px solid rgba(255, 255, 255, 0.12);
+	background: rgba(255, 255, 255, 0.04);
+	color: var(--gano-color-text-muted-on-dark, #94a3b8);
+	font-size: 0.8rem;
+	cursor: pointer;
+	transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.gano-atlas-chip:hover,
+.gano-atlas-chip:focus-visible {
+	border-color: var(--gano-gold-border, rgba(212, 175, 55, 0.4));
+	color: var(--gano-white, #fff);
+	outline: none;
+}
+
+.gano-atlas-chip.is-active {
+	background: var(--gano-gold-bg, rgba(212, 175, 55, 0.15));
+	border-color: var(--gano-gold, #d4af37);
+	color: var(--gano-white, #fff);
+}
+
+.gano-atlas-list {
+	list-style: none;
+	margin: 0;
+	padding: 0.5rem 0 1.25rem;
+	overflow-y: auto;
+	flex: 1;
+}
+
+.gano-atlas-item {
+	opacity: 0;
+	transform: translateY(6px);
+	animation: gano-atlas-in 0.38s ease forwards;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.gano-atlas-item:nth-child(1) { animation-delay: 0.02s; }
+.gano-atlas-item:nth-child(2) { animation-delay: 0.04s; }
+.gano-atlas-item:nth-child(3) { animation-delay: 0.06s; }
+.gano-atlas-item:nth-child(4) { animation-delay: 0.08s; }
+.gano-atlas-item:nth-child(5) { animation-delay: 0.1s; }
+.gano-atlas-item:nth-child(n+6) { animation-delay: 0.12s; }
+
+@keyframes gano-atlas-in {
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.gano-atlas-item {
+		animation: none;
+		opacity: 1;
+		transform: none;
+	}
+	.gano-atlas-sheet {
+		transition: none;
+	}
+	.gano-atlas-backdrop {
+		transition: none;
+	}
+}
+
+.gano-atlas-item.is-hidden {
+	display: none;
+}
+
+.gano-atlas-item__link {
+	display: flex;
+	flex-direction: column;
+	gap: 0.2rem;
+	padding: 0.85rem 1.25rem;
+	text-decoration: none;
+	color: inherit;
+	transition: background 0.15s ease;
+}
+
+.gano-atlas-item__link:hover,
+.gano-atlas-item__link:focus-visible {
+	background: rgba(212, 175, 55, 0.08);
+	outline: none;
+}
+
+.gano-atlas-item__title {
+	font-weight: 600;
+	color: var(--gano-white, #fff);
+	font-size: 0.95rem;
+}
+
+.gano-atlas-item__meta {
+	font-size: 0.75rem;
+	color: var(--gano-color-text-muted-on-dark, #94a3b8);
+}
+
+.gano-atlas-item__link:hover .gano-atlas-item__title,
+.gano-atlas-item__link:focus-visible .gano-atlas-item__title {
+	color: var(--gano-gold, #d4af37);
+}

--- a/wp-content/themes/gano-child/css/gano-start-journey.css
+++ b/wp-content/themes/gano-child/css/gano-start-journey.css
@@ -19,8 +19,22 @@ body.gano-page-start-journey .site,
 body.gano-page-start-journey #content,
 body.gano-page-start-journey .site-content,
 body.gano-page-start-journey #primary,
-body.gano-page-start-journey .content-area {
+body.gano-page-start-journey .content-area,
+body.gano-page-start-journey .site-main {
     background: transparent !important;
+}
+
+/* Vence fondos claros de Elementor / wrappers en la plantilla de página */
+body.gano-page-start-journey .site-content .entry-content,
+body.gano-page-start-journey .elementor-widget-container {
+    background: transparent !important;
+}
+
+body.gano-page-start-journey main.gano-start-journey.gano-km-shell {
+    background: radial-gradient(circle at 20% 0%, rgba(128, 131, 255, 0.14), transparent 38%),
+        radial-gradient(circle at 90% 30%, rgba(76, 215, 246, 0.1), transparent 42%),
+        linear-gradient(180deg, #0b1120 0%, #05080c 100%) !important;
+    color: rgba(226, 232, 240, 0.96) !important;
 }
 
 /* --------------------------------------------------------------------------
@@ -67,6 +81,7 @@ main.gano-start-journey.gano-on-dark > section {
 
 /* Hero (layout `.gano-km-hero`) */
 .gano-start-journey__hero {
+    position: relative;
     padding-top: clamp(3.25rem, 7vw, 5.25rem);
     padding-bottom: clamp(2.25rem, 6vw, 3.5rem);
     border-bottom: 1px solid rgba(192, 193, 255, 0.12);
@@ -87,12 +102,88 @@ main.gano-start-journey.gano-on-dark > section {
 
 /* El hero del DS tiene `max-width: 12ch`; en landing necesitamos más presencia */
 .gano-start-journey .gano-km-title {
-    max-width: 18ch;
+    max-width: 22ch;
+    color: #f8fafc !important;
 }
 
 .gano-start-journey .gano-km-lead {
-    color: rgba(226, 232, 240, 0.88);
-    font-size: clamp(1rem, 1.8vw, 1.18rem);
+    color: rgba(226, 232, 240, 0.94) !important;
+    font-size: clamp(1.02rem, 1.85vw, 1.2rem);
+    font-weight: 500;
+}
+
+.gano-start-journey__hero-main {
+    position: relative;
+    z-index: 1;
+}
+
+/* Pasos visibles: registro ocurre en checkout GoDaddy */
+.gano-start-journey__register-track {
+    list-style: none;
+    margin: 1.35rem 0 0;
+    padding: 1rem 1.1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(192, 193, 255, 0.2);
+    background: rgba(2, 6, 23, 0.45);
+    display: grid;
+    gap: 0.75rem;
+    max-width: 52ch;
+}
+
+.gano-start-journey__register-track li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.65rem 0.85rem;
+    align-items: start;
+    font-size: 0.92rem;
+    line-height: 1.45;
+    color: rgba(226, 232, 240, 0.95);
+}
+
+.gano-start-journey__register-track-step {
+    font-family: var(--gano-font-mono, ui-monospace, monospace);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--gano-landing-cyan, #4cd7f6);
+    padding-top: 0.2rem;
+    white-space: nowrap;
+}
+
+.gano-start-journey__register-track-text {
+    color: rgba(241, 245, 249, 0.96);
+}
+
+.gano-start-journey__hero-ctas {
+    margin-top: 1.5rem;
+}
+
+.gano-start-journey__cta-quiet {
+    border-style: dashed;
+    opacity: 0.95;
+}
+
+@media (min-width: 981px) {
+    .gano-start-journey__register-track {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem 1.25rem;
+        max-width: none;
+        padding: 1.1rem 1.25rem;
+    }
+
+    .gano-start-journey__register-track li {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        padding-left: 1rem;
+        border-left: 1px solid rgba(148, 163, 184, 0.22);
+    }
+
+    .gano-start-journey__register-track li:first-child {
+        border-left: 0;
+        padding-left: 0;
+    }
 }
 
 /* Acento del H1: color legible por defecto; gradiente solo con soporte de clip (WCAG / forced-colors) */
@@ -215,6 +306,8 @@ main.gano-start-journey.gano-on-dark > section {
 }
 
 .gano-start-journey__glass-title {
+    position: relative;
+    z-index: 1;
     margin: 0 0 0.85rem;
     font-size: 1.05rem;
     letter-spacing: -0.01em;
@@ -222,12 +315,14 @@ main.gano-start-journey.gano-on-dark > section {
 }
 
 .gano-start-journey__checklist {
+    position: relative;
+    z-index: 1;
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
     gap: 0.6rem;
-    color: rgba(226, 232, 240, 0.88);
+    color: rgba(226, 232, 240, 0.92);
     font-size: 0.95rem;
     line-height: 1.5;
 }
@@ -250,6 +345,8 @@ main.gano-start-journey.gano-on-dark > section {
 }
 
 .gano-start-journey__glass-cta {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-wrap: wrap;
     gap: 0.65rem;
@@ -483,6 +580,11 @@ main.gano-start-journey.gano-on-dark > section {
     display: flex;
     flex-wrap: wrap;
     gap: 0.65rem;
+}
+
+.gano-start-journey__path-row--stack {
+    flex-direction: column;
+    align-items: flex-start;
 }
 
 /* FAQ */

--- a/wp-content/themes/gano-child/css/homepage.css
+++ b/wp-content/themes/gano-child/css/homepage.css
@@ -454,6 +454,36 @@
     margin-bottom: 1rem;
 }
 
+.gano-home-section--atlas-below-hero {
+    padding-block: clamp(1rem, 2.5vw, 1.75rem);
+}
+
+/* Teaser comercial home: sin grid rStore (catálogo vive en /ecosistemas/) */
+.gano-home-section--commerce-teaser {
+    border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.gano-home-commerce-teaser {
+    text-align: center;
+    max-width: 46rem;
+    margin-inline: auto;
+}
+
+.gano-home-commerce-teaser .section-title-gano p {
+    color: rgba(203, 213, 225, 0.92);
+    font-size: clamp(0.95rem, 1.6vw, 1.05rem);
+    line-height: 1.65;
+}
+
+.gano-home-commerce-teaser__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+    margin-top: 1.5rem;
+}
+
 .ecosistemas-grid {
     margin-bottom: 20px;
 }

--- a/wp-content/themes/gano-child/front-page.php
+++ b/wp-content/themes/gano-child/front-page.php
@@ -6,6 +6,13 @@
  */
 
 get_header();
+
+$url_ecosistemas = function_exists( 'gano_resolve_page_url' )
+	? gano_resolve_page_url( 'ecosistemas' )
+	: home_url( '/ecosistemas/' );
+$url_shop = function_exists( 'gano_resolve_page_url' )
+	? gano_resolve_page_url( 'shop-premium', 'tienda', 'catalogo' )
+	: home_url( '/shop-premium/' );
 ?>
 
 <main class="gano-home" id="gano-home-main" data-gano-homepage>
@@ -19,22 +26,12 @@ get_header();
             <h1>Infraestructura NVMe blindada y un agente IA que trabaja antes de que algo falle.</h1>
             <p>Hosting WordPress de alto rendimiento con seguridad de nivel empresarial, soporte en español y operación en pesos colombianos. Menos ruido, más continuidad.</p>
             <div class="hero-cta-row">
-                <a href="#ecosistemas" class="btn-holo">
-                    <span class="label">Ver arquitecturas y planes</span>
+                <a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn-holo">
+                    <span class="label"><?php esc_html_e( 'Ver catálogo en Ecosistemas', 'gano-child' ); ?></span>
                     <span class="arrow">→</span>
                 </a>
-                <?php
-                $url_shop = function_exists( 'gano_resolve_page_url' )
-                    ? gano_resolve_page_url( 'shop-premium', 'tienda', 'catalogo' )
-                    : home_url( '/shop-premium/' );
-                ?>
-                <a href="<?php echo esc_url( $url_shop ); ?>" class="btn-gano btn-gano--secondary">Explorar catálogo inteligente</a>
+                <a href="<?php echo esc_url( $url_shop ); ?>" class="btn-gano btn-gano--secondary"><?php esc_html_e( 'Vista catálogo SOTA', 'gano-child' ); ?></a>
             </div>
-            <?php
-            if ( function_exists( 'gano_render_content_atlas' ) ) {
-                echo gano_render_content_atlas(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — markup propia del tema.
-            }
-            ?>
             <?php
             $url_comenzar = function_exists( 'gano_resolve_page_url' )
                 ? gano_resolve_page_url( 'comenzar-aqui', 'comenzar', 'registro-y-compra' )
@@ -45,6 +42,14 @@ get_header();
             </p>
         </div>
     </section>
+
+    <?php if ( function_exists( 'gano_render_content_atlas' ) ) : ?>
+    <section class="section-gano gano-home-section gano-home-section--atlas-below-hero" aria-label="<?php esc_attr_e( 'Atlas de lectura', 'gano-child' ); ?>">
+        <div class="gano-shell">
+            <?php echo gano_render_content_atlas(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        </div>
+    </section>
+    <?php endif; ?>
 
     <?php
     gano_cta_registro(array(
@@ -67,141 +72,28 @@ get_header();
         </div>
     </section>
 
-    <section class="section-gano gano-home-section" id="ecosistemas" data-gano-catalog aria-labelledby="ecosistemas-heading">
-        <div class="gano-shell">
+    <?php
+    // Teaser rStore de 4 tarjetas: borrador en inc/draft-home-rstore-catalog-home.php (filtro gano_show_draft_home_rstore_catalog).
+    ?>
+    <section class="section-gano gano-home-section gano-home-section--commerce-teaser" id="ecosistemas" aria-labelledby="ecosistemas-heading">
+        <div class="gano-shell gano-home-commerce-teaser">
             <div class="section-title-gano">
-                <h2 id="ecosistemas-heading">Ecosistemas SOTA 2026</h2>
-                <p>Elige el nivel de soporte, arquitectura y crecimiento que tu negocio necesita.</p>
-            </div>
-            <div class="gano-catalog-mode-switch" role="group" aria-label="Modo de navegación del catálogo">
-                <?php
-                $home_modes = function_exists( 'gano_get_catalog_nav_modes' ) ? gano_get_catalog_nav_modes() : array();
-                $home_primary_modes = array( 'grid', 'family' );
-                foreach ( $home_primary_modes as $mode_key ) :
-                    if ( ! isset( $home_modes[ $mode_key ] ) ) {
-                        continue;
-                    }
-                    ?>
-                    <button type="button" class="gano-catalog-mode-btn" data-gano-mode="<?php echo esc_attr( $mode_key ); ?>" aria-pressed="false">
-                        <?php echo esc_html( $home_modes[ $mode_key ]['label'] ); ?>
-                    </button>
-                <?php endforeach; ?>
-                <button type="button" class="gano-catalog-advanced-toggle" data-gano-advanced-toggle aria-expanded="false">
-                    Modos avanzados
-                </button>
-            </div>
-            <div class="gano-catalog-advanced-modes" data-gano-advanced-modes hidden>
-                <?php
-                if ( isset( $home_modes['guided'] ) ) :
-                    ?>
-                    <button type="button" class="gano-catalog-mode-btn" data-gano-mode="guided" aria-pressed="false">
-                        <?php echo esc_html( $home_modes['guided']['label'] ); ?>
-                    </button>
-                <?php endif; ?>
-            </div>
-            <p class="gano-catalog-mode-desc" data-gano-mode-description>
-                Navega por vista general, familias o asistente guiado según tu contexto.
-            </p>
-            <section class="gano-catalog-guided-panel" data-gano-guided-panel aria-label="Asistente de selección">
-                <ul class="gano-catalog-guided-list" data-gano-guided-list></ul>
-            </section>
-            <div class="ecosistemas-grid" id="catalog-container">
-                <?php
-                $ecosistemas = array(
-                    array(
-                        'nombre'    => 'Núcleo Prime',
-                        'slug'      => 'wordpress-basico',
-                        'precio'    => '$196.000',
-                        'categoria' => 'hostingwebcpanel',
-                        'features'  => array(
-                            'Almacenamiento NVMe',
-                            'Soporte en español por ticket',
-                            'Activación rápida'
-                        )
-                    ),
-                    array(
-                        'nombre'    => 'Fortaleza Delta',
-                        'slug'      => 'wordpress-deluxe',
-                        'precio'    => '$450.000',
-                        'categoria' => 'wordpressadministrado',
-                        'features'  => array(
-                            'Hardening activo incluido',
-                            'Mayor capacidad de recursos',
-                            'Respaldos automatizados'
-                        )
-                    ),
-                    array(
-                        'nombre'    => 'Bastión SOTA',
-                        'slug'      => 'wordpress-ultimate',
-                        'precio'    => '$890.000',
-                        'categoria' => 'seguridadweb',
-                        'features'  => array(
-                            'Recursos dedicados',
-                            'SLA ≥ 99.9%',
-                            'Monitoreo proactivo'
-                        )
-                    ),
-                    array(
-                        'nombre'    => 'Ultimate WP',
-                        'slug'      => 'cpanel-ultimate',
-                        'precio'    => '$1.200.000',
-                        'categoria' => 'servidoresvps',
-                        'features'  => array(
-                            'Máxima capacidad de recursos',
-                            'Blindaje ante picos masivos',
-                            'Soporte prioritario'
-                        )
-                    ),
-                );
-
-                foreach ( $ecosistemas as $eco ) :
-                    $product_query = new WP_Query(
-                        array(
-                            'post_type'      => 'reseller_product',
-                            'name'           => $eco['slug'],
-                            'posts_per_page' => 1,
-                        )
+                <h2 id="ecosistemas-heading"><?php esc_html_e( 'Catálogo comercial', 'gano-child' ); ?></h2>
+                <p>
+                    <?php
+                    echo esc_html(
+                        __( 'Compará planes con precios en COP y referencia USD*, filtros por familia y checkout seguro en la página Ecosistemas.', 'gano-child' )
                     );
-                    $post_id = $product_query->have_posts() ? $product_query->posts[0]->ID : null;
-                    wp_reset_postdata();
                     ?>
-                    <article
-                        class="ecosystem-card"
-                        data-category="<?php echo esc_attr( $eco['categoria'] ); ?>"
-                        data-product-id="<?php echo esc_attr( sanitize_title( $eco['slug'] ) ); ?>"
-                        data-product-name="<?php echo esc_attr( $eco['nombre'] ); ?>"
-                        data-product-price="<?php echo esc_attr( $eco['precio'] ); ?>"
-                    >
-                        <h3><?php echo esc_html( $eco['nombre'] ); ?></h3>
-                        <div class="price"><?php echo esc_html( $eco['precio'] ); ?></div>
-                        <ul>
-                            <?php foreach ( $eco['features'] as $feature ) : ?>
-                                <li><?php echo esc_html( $feature ); ?></li>
-                            <?php endforeach; ?>
-                        </ul>
-                        <?php
-                        if ( $post_id ) {
-                            echo do_shortcode( "[rstore_product post_id={$post_id} show_price=1 redirect=1 button_label='Elegir Plan']" );
-                        } else {
-                            echo '<a href="' . esc_url( home_url( '/contacto/' ) ) . '" class="btn-gano">Consultar</a>';
-                        }
-                        ?>
-                        <button type="button" class="gano-catalog-compare-toggle" data-gano-compare-toggle aria-pressed="false">
-                            Comparar
-                        </button>
-                    </article>
-                <?php endforeach; ?>
+                </p>
             </div>
-            <div class="gano-catalog-mobile-actions">
-                <button type="button" class="btn-gano btn-gano--secondary" data-gano-mobile-more aria-expanded="false">
-                    Ver más planes
-                </button>
+            <div class="gano-home-commerce-teaser__actions">
+                <a class="btn-holo" href="<?php echo esc_url( $url_ecosistemas ); ?>">
+                    <span class="label"><?php esc_html_e( 'Abrir catálogo en Ecosistemas', 'gano-child' ); ?></span>
+                    <span class="arrow" aria-hidden="true">→</span>
+                </a>
+                <a class="btn-gano btn-gano--secondary" href="<?php echo esc_url( $url_shop ); ?>"><?php esc_html_e( 'Vista SOTA (shop-premium)', 'gano-child' ); ?></a>
             </div>
-            <section class="gano-catalog-comparator" data-gano-compare hidden>
-                <h3 class="gano-catalog-comparator-title">Comparador inteligente (hasta 3)</h3>
-                <ul class="gano-catalog-compare-list" data-gano-compare-list></ul>
-                <div class="gano-catalog-compare-grid" data-gano-compare-grid></div>
-            </section>
         </div>
     </section>
 
@@ -300,7 +192,7 @@ get_header();
                 <h2 id="cierre-heading">¿Listo para una infraestructura que no te pida disculpas?</h2>
                 <?php echo do_shortcode( '[gano_cta_icons]' ); ?>
                 <p class="gano-panel-cta">
-                    <a href="#ecosistemas" class="btn-gano">Elegir mi arquitectura</a>
+                    <a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn-gano"><?php esc_html_e( 'Elegir mi arquitectura', 'gano-child' ); ?></a>
                 </p>
             </div>
         </div>

--- a/wp-content/themes/gano-child/front-page.php
+++ b/wp-content/themes/gano-child/front-page.php
@@ -30,14 +30,11 @@ get_header();
                 ?>
                 <a href="<?php echo esc_url( $url_shop ); ?>" class="btn-gano btn-gano--secondary">Explorar catálogo inteligente</a>
             </div>
-            <div class="hero-gano__proof-glass">
-                <p class="hero-gano__proof-label"><?php esc_html_e( 'Marco operativo', 'gano-child' ); ?></p>
-                <ul class="hero-proof-bar" aria-label="<?php esc_attr_e( 'Marco operativo: SLA, endurecimiento y operación local', 'gano-child' ); ?>">
-                    <li><strong><?php esc_html_e( 'SLA', 'gano-child' ); ?></strong><span><?php esc_html_e( 'Acuerdos de nivel de servicio explícitos', 'gano-child' ); ?></span></li>
-                    <li><strong><?php esc_html_e( 'Hardening', 'gano-child' ); ?></strong><span><?php esc_html_e( 'WordPress endurecido y monitoreado', 'gano-child' ); ?></span></li>
-                    <li><strong><?php esc_html_e( 'COP', 'gano-child' ); ?></strong><span><?php esc_html_e( 'Facturación y operación en Colombia', 'gano-child' ); ?></span></li>
-                </ul>
-            </div>
+            <?php
+            if ( function_exists( 'gano_render_content_atlas' ) ) {
+                echo gano_render_content_atlas(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — markup propia del tema.
+            }
+            ?>
             <?php
             $url_comenzar = function_exists( 'gano_resolve_page_url' )
                 ? gano_resolve_page_url( 'comenzar-aqui', 'comenzar', 'registro-y-compra' )

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -13,6 +13,7 @@
 // =============================================================================
 
 require_once get_stylesheet_directory() . '/inc/homepage-blocks.php';
+require_once get_stylesheet_directory() . '/inc/gano-content-atlas.php';
 require_once get_stylesheet_directory() . '/inc/contact-form-handler.php';
 require_once get_stylesheet_directory() . '/inc/lead-magnet-handler.php';
 require_once get_stylesheet_directory() . '/inc/gano-premium-components.php';
@@ -314,6 +315,9 @@ function gano_child_enqueue_styles() {
                 'leadEndpoint' => rest_url( 'gano/v1/lead-capture' ),
             )
         );
+        if ( function_exists( 'gano_content_atlas_enqueue_assets' ) ) {
+            gano_content_atlas_enqueue_assets();
+        }
     }
 
     // Navegación sticky — todas las páginas

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -14,6 +14,7 @@
 
 require_once get_stylesheet_directory() . '/inc/homepage-blocks.php';
 require_once get_stylesheet_directory() . '/inc/gano-content-atlas.php';
+require_once get_stylesheet_directory() . '/inc/draft-home-rstore-catalog-home.php';
 require_once get_stylesheet_directory() . '/inc/contact-form-handler.php';
 require_once get_stylesheet_directory() . '/inc/lead-magnet-handler.php';
 require_once get_stylesheet_directory() . '/inc/gano-premium-components.php';
@@ -447,8 +448,8 @@ function gano_child_enqueue_styles() {
     }
 
     // Smart catalog UX — shared by commercial templates (grid/family/guided + comparator + analytics hooks)
+    // Home (front-page) ya no incluye `[data-gano-catalog]` — no cargar UX catálogo ahí.
     $is_commerce_template =
-        is_front_page() ||
         is_page_template( 'templates/shop-premium.php' ) ||
         is_page_template( 'templates/page-ecosistemas.php' ) ||
         is_page_template( 'templates/page-seo-landing.php' );

--- a/wp-content/themes/gano-child/inc/draft-home-rstore-catalog-home.php
+++ b/wp-content/themes/gano-child/inc/draft-home-rstore-catalog-home.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Borrador — bloque “4 planes” con shortcodes rstore en home (retirado del landing).
+ *
+ * El widget rstore suele traer estilos naranja de marca; lo dejamos aquí por si se
+ * requiere de nuevo un teaser rápido en la portada.
+ *
+ * Uso (solo si lo necesitas):
+ * 1. En `front-page.php`, tras el teaser comercial, llama:
+ *    `gano_draft_render_home_rstore_catalog_teaser_block();`
+ * 2. O engancha a un hook propio y devuelve true en el filtro:
+ *    `add_filter( 'gano_show_draft_home_rstore_catalog', '__return_true' );`
+ *
+ * @package gano-child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Imprime la sección draft (grid + rstore_product) si el filtro lo permite.
+ *
+ * @return void
+ */
+function gano_draft_render_home_rstore_catalog_teaser_block() {
+	if ( ! apply_filters( 'gano_show_draft_home_rstore_catalog', false ) ) {
+		return;
+	}
+
+	$url_ecosistemas = function_exists( 'gano_resolve_page_url' )
+		? gano_resolve_page_url( 'ecosistemas' )
+		: home_url( '/ecosistemas/' );
+
+	?>
+	<section class="section-gano gano-home-section gano-home-section--surface gano-draft-rstore-catalog" data-gano-catalog aria-labelledby="gano-draft-ecosistemas-heading">
+		<div class="gano-shell">
+			<div class="section-title-gano">
+				<h2 id="gano-draft-ecosistemas-heading"><?php esc_html_e( '[Borrador] Planes destacados (rstore)', 'gano-child' ); ?></h2>
+				<p><?php esc_html_e( 'Solo visible si gano_show_draft_home_rstore_catalog está activo.', 'gano-child' ); ?></p>
+				<p><a class="btn-gano" href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Ir al catálogo SOTA en Ecosistemas', 'gano-child' ); ?></a></p>
+			</div>
+			<div class="ecosistemas-grid" id="catalog-container">
+				<?php
+				$ecosistemas = array(
+					array(
+						'nombre'    => 'Núcleo Prime',
+						'slug'      => 'wordpress-basico',
+						'precio'    => '$196.000',
+						'categoria' => 'hostingwebcpanel',
+						'features'  => array(
+							'Almacenamiento NVMe',
+							'Soporte en español por ticket',
+							'Activación rápida',
+						),
+					),
+					array(
+						'nombre'    => 'Fortaleza Delta',
+						'slug'      => 'wordpress-deluxe',
+						'precio'    => '$450.000',
+						'categoria' => 'wordpressadministrado',
+						'features'  => array(
+							'Hardening activo incluido',
+							'Mayor capacidad de recursos',
+							'Respaldos automatizados',
+						),
+					),
+					array(
+						'nombre'    => 'Bastión SOTA',
+						'slug'      => 'wordpress-ultimate',
+						'precio'    => '$890.000',
+						'categoria' => 'seguridadweb',
+						'features'  => array(
+							'Recursos dedicados',
+							'SLA ≥ 99.9%',
+							'Monitoreo proactivo',
+						),
+					),
+					array(
+						'nombre'    => 'Ultimate WP',
+						'slug'      => 'cpanel-ultimate',
+						'precio'    => '$1.200.000',
+						'categoria' => 'servidoresvps',
+						'features'  => array(
+							'Máxima capacidad de recursos',
+							'Blindaje ante picos masivos',
+							'Soporte prioritario',
+						),
+					),
+				);
+
+				foreach ( $ecosistemas as $eco ) {
+					$product_query = new WP_Query(
+						array(
+							'post_type'      => 'reseller_product',
+							'name'           => $eco['slug'],
+							'posts_per_page' => 1,
+						)
+					);
+					$post_id = $product_query->have_posts() ? $product_query->posts[0]->ID : null;
+					wp_reset_postdata();
+					?>
+					<article
+						class="ecosystem-card"
+						data-category="<?php echo esc_attr( $eco['categoria'] ); ?>"
+						data-product-id="<?php echo esc_attr( sanitize_title( $eco['slug'] ) ); ?>"
+						data-product-name="<?php echo esc_attr( $eco['nombre'] ); ?>"
+						data-product-price="<?php echo esc_attr( $eco['precio'] ); ?>"
+					>
+						<h3><?php echo esc_html( $eco['nombre'] ); ?></h3>
+						<div class="price"><?php echo esc_html( $eco['precio'] ); ?></div>
+						<ul>
+							<?php foreach ( $eco['features'] as $feature ) : ?>
+								<li><?php echo esc_html( $feature ); ?></li>
+							<?php endforeach; ?>
+						</ul>
+						<?php
+						if ( $post_id ) {
+							echo do_shortcode( "[rstore_product post_id={$post_id} show_price=1 redirect=1 button_label='Elegir Plan']" );
+						} else {
+							echo '<a href="' . esc_url( home_url( '/contacto/' ) ) . '" class="btn-gano">Consultar</a>';
+						}
+						?>
+					</article>
+					<?php
+				}
+				?>
+			</div>
+		</div>
+	</section>
+	<?php
+}

--- a/wp-content/themes/gano-child/inc/gano-content-atlas.php
+++ b/wp-content/themes/gano-child/inc/gano-content-atlas.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Atlas de lectura — índice curado de páginas y entradas (shortcode + hero).
+ *
+ * Widget Elementor → Código corto: [gano_content_atlas]
+ *
+ * Opción `gano_atlas_curated_slugs`: slugs extra separados por comas.
+ *
+ * @package gano-child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Slugs curados por defecto (orden por título en PHP).
+ *
+ * @return string[]
+ */
+function gano_atlas_default_curated_slugs(): array {
+	return array_unique(
+		array(
+			'almacenamiento-nvme',
+			'arquitectura-cloud',
+			'blog',
+			'ciber-resiliencia-fractal',
+			'computacion-serverless',
+			'como-elegir-nombre-dominio-negocio',
+			'comenzar-aqui',
+			'catalogo-sota',
+			'contacto',
+			'diagnostico-digital',
+			'dominios',
+			'ecosistemas',
+			'ecosistemas-hibridos',
+			'edge-computing-pro',
+			'hosting',
+			'hosting-compartido-vs-vps',
+			'hub-sota',
+			'inteligencia-sintetica',
+			'manifiesto-nvme-velocidad-nueva-seguridad',
+			'nosotros',
+			'politica-de-cookies',
+			'politica-de-privacidad',
+			'por-que-empresa-necesita-pagina-web',
+			'red-global-anycast',
+			'seguridad-zero-trust',
+			'seo-landing',
+			'servicios',
+			'shop-premium',
+			'soberania-digital',
+			'soberania-digital-derecho-propiedad-datos',
+			'soporte',
+			'sota-hub',
+			'terminos-y-condiciones',
+			'zero-trust-blindando-perimetro',
+		)
+	);
+}
+
+/**
+ * @param WP_Post $post Post object.
+ * @return string pilares|guias|legal
+ */
+function gano_atlas_classify_post( WP_Post $post ): string {
+	$slug = $post->post_name;
+	$legal = array( 'politica-de-privacidad', 'terminos-y-condiciones', 'politica-de-cookies' );
+	if ( in_array( $slug, $legal, true ) ) {
+		return 'legal';
+	}
+	$guias_slugs = array(
+		'por-que-empresa-necesita-pagina-web',
+		'como-elegir-nombre-dominio-negocio',
+		'hosting-compartido-vs-vps',
+		'comenzar-aqui',
+	);
+	if ( 'post' === $post->post_type || in_array( $slug, $guias_slugs, true ) ) {
+		return 'guias';
+	}
+	return 'pilares';
+}
+
+/**
+ * @return WP_Post[]
+ */
+function gano_atlas_get_curated_posts(): array {
+	$extra = get_option( 'gano_atlas_curated_slugs', '' );
+	$slugs = gano_atlas_default_curated_slugs();
+	if ( is_string( $extra ) && $extra !== '' ) {
+		$more  = array_filter( array_map( 'trim', explode( ',', $extra ) ) );
+		$slugs = array_values( array_unique( array_merge( $slugs, $more ) ) );
+	}
+
+	$woo_block = array( 'shop', 'cart', 'checkout', 'my-account' );
+	$by_id     = array();
+
+	foreach ( $slugs as $slug ) {
+		if ( in_array( $slug, $woo_block, true ) ) {
+			continue;
+		}
+		$p = get_page_by_path( $slug, OBJECT, 'page' );
+		if ( ! $p || 'publish' !== $p->post_status ) {
+			$q = get_posts(
+				array(
+					'name'           => $slug,
+					'post_type'      => 'post',
+					'post_status'    => 'publish',
+					'posts_per_page' => 1,
+				)
+			);
+			$p = ! empty( $q[0] ) ? $q[0] : null;
+		}
+		if ( $p instanceof WP_Post ) {
+			$by_id[ $p->ID ] = $p;
+		}
+	}
+
+	$out = array_values( $by_id );
+	usort(
+		$out,
+		static function ( WP_Post $a, WP_Post $b ) {
+			return strcasecmp( $a->post_title, $b->post_title );
+		}
+	);
+	return $out;
+}
+
+/**
+ * Encola CSS/JS del Atlas (una vez por request).
+ */
+function gano_content_atlas_enqueue_assets(): void {
+	static $done = false;
+	if ( $done ) {
+		return;
+	}
+	$done = true;
+
+	$css = get_stylesheet_directory() . '/css/gano-content-atlas.css';
+	$js  = get_stylesheet_directory() . '/js/gano-content-atlas.js';
+	$ver = wp_get_theme()->get( 'Version' );
+	if ( file_exists( $css ) ) {
+		$ver = (string) filemtime( $css );
+	}
+	wp_enqueue_style(
+		'gano-content-atlas',
+		get_stylesheet_directory_uri() . '/css/gano-content-atlas.css',
+		array( 'gano-child-style' ),
+		$ver
+	);
+	$ver_js = file_exists( $js ) ? (string) filemtime( $js ) : $ver;
+	wp_enqueue_script(
+		'gano-content-atlas',
+		get_stylesheet_directory_uri() . '/js/gano-content-atlas.js',
+		array(),
+		$ver_js,
+		true
+	);
+}
+
+/**
+ * @param array<string,mixed> $args Unused; reservado.
+ * @return string HTML.
+ */
+function gano_render_content_atlas( array $args = array() ): string {
+	gano_content_atlas_enqueue_assets();
+
+	$items = gano_atlas_get_curated_posts();
+	if ( empty( $items ) ) {
+		return '';
+	}
+
+	$uid = 'gano-atlas-' . wp_unique_id();
+
+	$labels = array(
+		'pilares' => __( 'Pilar', 'gano-child' ),
+		'guias'   => __( 'Guía', 'gano-child' ),
+		'legal'   => __( 'Legal', 'gano-child' ),
+	);
+
+	ob_start();
+	?>
+<div class="gano-atlas-root" data-gano-atlas-root>
+<div class="gano-atlas-hero gano-atlas-hero--sota" data-gano-atlas-intro>
+	<div class="gano-atlas-hero__text">
+		<p class="gano-atlas-hero__eyebrow"><?php esc_html_e( 'SOTA — State of the Art', 'gano-child' ); ?></p>
+		<p class="gano-atlas-hero__copy">
+			<?php esc_html_e( 'En Gano Digital, SOTA es nuestro estándar: arquitectura y operación al nivel que el mercado considera “lo mejor disponible hoy”, sin humo ni promesas genéricas. Lo aplicamos a hosting, seguridad y acompañamiento comercial para que tu equipo sepa exactamente qué compra y por qué.', 'gano-child' ); ?>
+		</p>
+	</div>
+	<div class="gano-atlas-hero__action">
+		<button type="button" class="gano-atlas-open btn-holo" aria-expanded="false" aria-controls="<?php echo esc_attr( $uid ); ?>-sheet" data-gano-atlas-open>
+			<span class="label"><?php esc_html_e( 'Mapa de lectura', 'gano-child' ); ?></span>
+			<span class="arrow" aria-hidden="true">→</span>
+		</button>
+		<p class="gano-atlas-hero__hint">
+			<?php
+			$url_cat = function_exists( 'gano_resolve_page_url' )
+				? gano_resolve_page_url( 'catalogo-sota', 'sota-hub' )
+				: home_url( '/catalogo-sota/' );
+			?>
+			<a href="<?php echo esc_url( $url_cat ); ?>"><?php esc_html_e( 'Ver índice editorial completo →', 'gano-child' ); ?></a>
+		</p>
+	</div>
+</div>
+
+<div class="gano-atlas-backdrop" data-gano-atlas-backdrop hidden></div>
+<div id="<?php echo esc_attr( $uid ); ?>-sheet" class="gano-atlas-sheet" data-gano-atlas-sheet hidden role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Mapa de lectura del sitio', 'gano-child' ); ?>">
+	<div class="gano-atlas-sheet__head">
+		<h2 class="gano-atlas-sheet__title"><?php esc_html_e( 'Atlas de lectura', 'gano-child' ); ?></h2>
+		<button type="button" class="gano-atlas-close" data-gano-atlas-close aria-label="<?php esc_attr_e( 'Cerrar', 'gano-child' ); ?>">×</button>
+	</div>
+	<div class="gano-atlas-chips" role="tablist" aria-label="<?php esc_attr_e( 'Filtrar por categoría', 'gano-child' ); ?>">
+		<button type="button" class="gano-atlas-chip is-active" data-atlas-filter="todos"><?php esc_html_e( 'Todos', 'gano-child' ); ?></button>
+		<button type="button" class="gano-atlas-chip" data-atlas-filter="pilares"><?php esc_html_e( 'Pilares SOTA', 'gano-child' ); ?></button>
+		<button type="button" class="gano-atlas-chip" data-atlas-filter="guias"><?php esc_html_e( 'Guías', 'gano-child' ); ?></button>
+		<button type="button" class="gano-atlas-chip" data-atlas-filter="legal"><?php esc_html_e( 'Legal', 'gano-child' ); ?></button>
+	</div>
+	<ul class="gano-atlas-list">
+		<?php foreach ( $items as $post ) : ?>
+			<?php
+			$group = gano_atlas_classify_post( $post );
+			$url   = get_permalink( $post );
+			$type  = 'post' === $post->post_type ? __( 'Artículo', 'gano-child' ) : __( 'Página', 'gano-child' );
+			$lab   = isset( $labels[ $group ] ) ? $labels[ $group ] : $group;
+			?>
+			<li class="gano-atlas-item" data-atlas-group="<?php echo esc_attr( $group ); ?>">
+				<a class="gano-atlas-item__link" href="<?php echo esc_url( $url ); ?>">
+					<span class="gano-atlas-item__title"><?php echo esc_html( get_the_title( $post ) ); ?></span>
+					<span class="gano-atlas-item__meta"><?php echo esc_html( $type . ' · ' . $lab ); ?></span>
+				</a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>
+</div>
+	<?php
+	return (string) ob_get_clean();
+}
+
+add_shortcode(
+	'gano_content_atlas',
+	static function () {
+		return gano_render_content_atlas();
+	}
+);

--- a/wp-content/themes/gano-child/js/catalog-sota.js
+++ b/wp-content/themes/gano-child/js/catalog-sota.js
@@ -17,8 +17,39 @@
     return `https://cart.secureserver.net/?plid=${PLID}&pfid=${pfid}`;
   }
 
-  /* ── Price helpers ── */
-  function fmt(n) { return window.formatCOP ? window.formatCOP(n) : ('$' + n); }
+  /* ── Price helpers (COP dinámico + USD* en paralelo) ── */
+  function copStr(usd) {
+    if (window.formatCOPFromUsd) return window.formatCOPFromUsd(usd);
+    const r = (window.ganoCatalogWP && Number(window.ganoCatalogWP.usdCop)) || 4100;
+    return '$' + Math.round(Number(usd) * r).toLocaleString('es-CO') + ' COP';
+  }
+  function usdStr(usd) {
+    if (window.formatUSDRef) return window.formatUSDRef(usd);
+    return 'USD $' + Number(usd).toFixed(2) + '*';
+  }
+  /** Bloque visual: línea principal COP + línea secundaria USD* */
+  function dualAmount(usdValue, perSuffix) {
+    const per = perSuffix || '';
+    return (
+      '<div class="price-dual">' +
+      '<div class="price-dual__row price-dual__primary">' +
+      '<span class="price-cop">' + copStr(usdValue) + '</span>' +
+      '<span class="price-per">' + per + '</span>' +
+      '</div>' +
+      '<div class="price-dual__row price-dual__secondary">' +
+      '<span class="price-usd-ref">' + usdStr(usdValue) + '</span>' +
+      '<span class="price-per price-per--muted">' + per + '</span>' +
+      '</div></div>'
+    );
+  }
+  function dualStrike(usdMonthly) {
+    return (
+      '<div class="price-strike-dual">' +
+      '<span>' + copStr(usdMonthly) + '<span class="price-strike-sub">/mes</span></span>' +
+      '<span class="price-strike-usd">' + usdStr(usdMonthly) + '<span class="price-strike-sub">/mes</span></span>' +
+      '</div>'
+    );
+  }
   function monthlyEstimate(yearly) { return yearly ? Math.round(yearly / 12) : null; }
 
   /* ── Badge map ── */
@@ -89,28 +120,28 @@
     }
 
     if (isAnnual && hasYearly) {
-      const mo = monthlyEstimate(p.yearly);
-      const strike = hasMonthly ? `<span class="price-strike">${fmt(p.monthly)}/mes</span>` : '';
-      const save = hasMonthly && mo
-        ? `<span class="price-save">Ahorras ${fmt((p.monthly * 12) - p.yearly)}/año</span>` : '';
-      return `
-        ${strike}
-        <span class="price-val">${fmt(p.yearly)}</span>
-        <span class="price-per">/año</span>
-        ${save}`;
-    } else if (!isAnnual && hasMonthly) {
-      return `
-        <span class="price-val">${fmt(p.monthly)}</span>
-        <span class="price-per">/mes</span>`;
-    } else if (hasYearly) {
-      // monthly only shown, yearly product — show estimated
-      const mo = monthlyEstimate(p.yearly);
-      return `
-        <span class="price-val">${fmt(mo)}</span>
-        <span class="price-per">/mes est.</span>`;
-    } else {
-      return `<span class="price-val">${fmt(p.yearly)}</span><span class="price-per">/año</span>`;
+      const strike = hasMonthly ? dualStrike(p.monthly) : '';
+      const annualSave =
+        hasMonthly && p.monthly != null && p.yearly != null
+          ? p.monthly * 12 - p.yearly
+          : 0;
+      const save =
+        annualSave > 0.009
+          ? (
+            '<span class="price-save">Ahorras ' + copStr(annualSave) + ' · ' +
+            '<span class="price-save-usd">' + usdStr(annualSave) + '</span>/año</span>'
+          )
+          : '';
+      return strike + dualAmount(p.yearly, '/año') + save;
     }
+    if (!isAnnual && hasMonthly) {
+      return dualAmount(p.monthly, '/mes');
+    }
+    if (hasYearly) {
+      const mo = monthlyEstimate(p.yearly);
+      return dualAmount(mo, '/mes est.');
+    }
+    return dualAmount(p.yearly, '/año');
   }
 
   /* ── Build CTA ── */
@@ -277,14 +308,17 @@
   }
 
   /* ── Price toggle ── */
-  document.getElementById('price-toggle').addEventListener('change', function () {
-    isAnnual = this.checked;
-    const lm = document.getElementById('lbl-monthly');
-    const la = document.getElementById('lbl-annual');
-    if (lm) { lm.classList.toggle('on', !isAnnual); }
-    if (la) { la.classList.toggle('on', isAnnual); }
-    updatePrices();
-  });
+  const priceToggleEl = document.getElementById('price-toggle');
+  if (priceToggleEl) {
+    priceToggleEl.addEventListener('change', function () {
+      isAnnual = this.checked;
+      const lm = document.getElementById('lbl-monthly');
+      const la = document.getElementById('lbl-annual');
+      if (lm) { lm.classList.toggle('on', !isAnnual); }
+      if (la) { la.classList.toggle('on', isAnnual); }
+      updatePrices();
+    });
+  }
 
   /* ── Global filter handlers (called from inline onclick) ── */
   window.setCat = function (btn, id) {
@@ -310,9 +344,10 @@
 
   /* ── Init ── */
   function init() {
-    // Set toggle to annual by default
     const tog = document.getElementById('price-toggle');
-    if (tog) { tog.checked = true; }
+    if (tog) {
+      tog.checked = true;
+    }
     document.getElementById('lbl-annual')?.classList.add('on');
     document.getElementById('lbl-monthly')?.classList.remove('on');
 

--- a/wp-content/themes/gano-child/js/catalog-sota.js
+++ b/wp-content/themes/gano-child/js/catalog-sota.js
@@ -191,13 +191,61 @@
 </article>`;
   }
 
+  function sortedProducts() {
+    const cats = (window.GANO_CATEGORIES || []).filter(function (c) { return c.id !== 'all'; });
+    const rank = {};
+    cats.forEach(function (c, i) { rank[c.id] = i; });
+    return window.GANO_PRODUCTS.slice().sort(function (a, b) {
+      const ra = rank[a.category] != null ? rank[a.category] : 999;
+      const rb = rank[b.category] != null ? rank[b.category] : 999;
+      if (ra !== rb) return ra - rb;
+      return (a.name || '').localeCompare(b.name || '');
+    });
+  }
+
+  function renderCategoryHeader(catId) {
+    const meta = (window.GANO_CATEGORIES || []).find(function (c) { return c.id === catId; });
+    const title = meta ? meta.label : catId;
+    const icon = meta ? meta.icon : 'fa-layer-group';
+    const count = window.GANO_PRODUCTS.filter(function (x) { return x.category === catId; }).length;
+    return (
+      '<div class="gano-cat-header" data-cat-head="' + catId + '" role="presentation">' +
+      '<div class="gano-cat-header-icon"><i class="fa-solid ' + icon + '"></i></div>' +
+      '<span class="gano-cat-header-name">' + title + '</span>' +
+      '<span class="gano-cat-header-count">' + count + ' productos</span></div>'
+    );
+  }
+
+  function syncCategoryHeaders() {
+    document.querySelectorAll('.gano-cat-header').forEach(function (h) {
+      const cat = h.getAttribute('data-cat-head');
+      if (!cat) return;
+      const n = document.querySelectorAll('.pcard[data-cat="' + cat + '"]:not(.hidden)').length;
+      h.classList.toggle('gano-cat-header--empty', n === 0);
+    });
+  }
+
   /* ── Render all cards ── */
   function renderGrid() {
     const grid = document.getElementById('product-grid');
     if (!grid || !window.GANO_PRODUCTS) return;
-    grid.innerHTML = window.GANO_PRODUCTS.map(renderCard).join('');
+    if (activeCategory === 'all') {
+      const parts = [];
+      let lastCat = null;
+      sortedProducts().forEach(function (p) {
+        if (p.category !== lastCat) {
+          lastCat = p.category;
+          parts.push(renderCategoryHeader(p.category));
+        }
+        parts.push(renderCard(p));
+      });
+      grid.innerHTML = parts.join('');
+    } else {
+      grid.innerHTML = window.GANO_PRODUCTS.map(renderCard).join('');
+    }
     updateCount();
     bindGlossaryTips();
+    syncCategoryHeaders();
   }
 
   /* ── Filter logic ── */
@@ -215,6 +263,7 @@
       card.classList.toggle('hidden', shouldHide(p));
     });
     updateCount();
+    syncCategoryHeaders();
   }
 
   function updateCount() {
@@ -325,7 +374,7 @@
     document.querySelectorAll('.ftab').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     activeCategory = id;
-    applyFilters();
+    renderGrid();
   };
 
   window.setObj = function (btn, id) {

--- a/wp-content/themes/gano-child/js/gano-catalog-intelligence.js
+++ b/wp-content/themes/gano-child/js/gano-catalog-intelligence.js
@@ -22,18 +22,18 @@
     toggle.className = "gano-mobile-nav-toggle";
     toggle.setAttribute("aria-label", "Abrir navegación");
     toggle.setAttribute("aria-expanded", "false");
-    toggle.innerHTML = "☰";
+    toggle.innerHTML = "\u2630";
 
     const panel = document.createElement("aside");
     panel.className = "gano-mobile-nav-panel";
     panel.setAttribute("aria-label", "Navegación móvil");
     panel.innerHTML =
       '<a href="/">Inicio</a>' +
-      '<a href="/ecosistemas">Ecosistemas</a>' +
-      '<a href="/shop-premium">Catálogo</a>' +
-      '<a href="/sota-hub">SOTA Hub</a>' +
-      '<a href="/diagnostico-digital">Diagnóstico</a>' +
-      '<a href="/contacto" class="gano-mobile-nav-cta">Hablar con ventas</a>' +
+      '<a href="/ecosistemas/">Ecosistemas</a>' +
+      '<a href="/shop-premium/">Catálogo</a>' +
+      '<a href="/sota-hub/">SOTA Hub</a>' +
+      '<a href="/diagnostico-digital/">Diagnóstico</a>' +
+      '<a href="/contacto/" class="gano-mobile-nav-cta">Hablar con ventas</a>' +
       '<a href="#" data-gano-close-mobile-nav>Cerrar</a>';
 
     header.appendChild(toggle);

--- a/wp-content/themes/gano-child/js/gano-content-atlas.js
+++ b/wp-content/themes/gano-child/js/gano-content-atlas.js
@@ -1,0 +1,101 @@
+/**
+ * Atlas de lectura — sheet, chips, Escape.
+ */
+(function () {
+	'use strict';
+
+	function closest(el, sel) {
+		while (el && el !== document) {
+			if (el.matches && el.matches(sel)) return el;
+			el = el.parentElement;
+		}
+		return null;
+	}
+
+	function openAtlas(root) {
+		var sheet = root.querySelector('[data-gano-atlas-sheet]');
+		var backdrop = root.querySelector('[data-gano-atlas-backdrop]');
+		var btn = root.querySelector('[data-gano-atlas-open]');
+		if (!sheet || !backdrop) return;
+		sheet.hidden = false;
+		backdrop.hidden = false;
+		requestAnimationFrame(function () {
+			backdrop.classList.add('is-visible');
+			sheet.classList.add('is-open');
+		});
+		if (btn) btn.setAttribute('aria-expanded', 'true');
+		var closeBtn = sheet.querySelector('[data-gano-atlas-close]');
+		if (closeBtn) closeBtn.focus();
+		document.body.style.overflow = 'hidden';
+	}
+
+	function closeAtlas(root) {
+		var sheet = root.querySelector('[data-gano-atlas-sheet]');
+		var backdrop = root.querySelector('[data-gano-atlas-backdrop]');
+		var btn = root.querySelector('[data-gano-atlas-open]');
+		if (!sheet || !backdrop) return;
+		backdrop.classList.remove('is-visible');
+		sheet.classList.remove('is-open');
+		if (btn) btn.setAttribute('aria-expanded', 'false');
+		document.body.style.overflow = '';
+		setTimeout(function () {
+			sheet.hidden = true;
+			backdrop.hidden = true;
+		}, 280);
+		if (btn) btn.focus();
+	}
+
+	function filterItems(root, filter) {
+		root.querySelectorAll('.gano-atlas-item').forEach(function (li) {
+			var g = li.getAttribute('data-atlas-group') || '';
+			if (filter === 'todos' || g === filter) {
+				li.classList.remove('is-hidden');
+			} else {
+				li.classList.add('is-hidden');
+			}
+		});
+	}
+
+	document.addEventListener('click', function (e) {
+		var openBtn = closest(e.target, '[data-gano-atlas-open]');
+		if (openBtn) {
+			e.preventDefault();
+			var root = openBtn.closest('[data-gano-atlas-root]');
+			if (root) openAtlas(root);
+			return;
+		}
+		var closeBtn = closest(e.target, '[data-gano-atlas-close]');
+		if (closeBtn) {
+			var sheet = closeBtn.closest('[data-gano-atlas-sheet]');
+			var root = sheet ? sheet.closest('[data-gano-atlas-root]') : null;
+			if (root) closeAtlas(root);
+			return;
+		}
+		var bd = closest(e.target, '[data-gano-atlas-backdrop]');
+		if (bd && bd.classList.contains('is-visible')) {
+			var root2 = bd.closest('[data-gano-atlas-root]');
+			if (root2) closeAtlas(root2);
+		}
+	});
+
+	document.addEventListener('click', function (e) {
+		var chip = closest(e.target, '.gano-atlas-chip');
+		if (!chip) return;
+		var sheet = chip.closest('[data-gano-atlas-sheet]');
+		if (!sheet) return;
+		var root = sheet.closest('[data-gano-atlas-root]');
+		if (!root) return;
+		var filter = chip.getAttribute('data-atlas-filter') || 'todos';
+		sheet.querySelectorAll('.gano-atlas-chip').forEach(function (c) {
+			c.classList.toggle('is-active', c === chip);
+		});
+		filterItems(root, filter);
+	});
+
+	document.addEventListener('keydown', function (e) {
+		if (e.key !== 'Escape') return;
+		var openSheet = document.querySelector('.gano-atlas-sheet.is-open');
+		var root = openSheet ? openSheet.closest('[data-gano-atlas-root]') : null;
+		if (root) closeAtlas(root);
+	});
+})();

--- a/wp-content/themes/gano-child/js/reseller-data.js
+++ b/wp-content/themes/gano-child/js/reseller-data.js
@@ -1115,17 +1115,44 @@ window.GANO_CATEGORIES = [
   { id: 'dominios', label: 'Dominios', icon: 'fa-globe' },
 ];
 
-// Format helpers
-// Asume que el precio de entrada es en USD (ej. 9.99).
-// Formatea con prefijo USD para evitar confusión.
-window.formatCOP = function(n) {
-  if (n == null) return '—';
-  // Formato USD estricto: USD $9.99
-  return 'USD $' + n.toFixed(2);
+// ── Precios: datos catálogo en USD; COP derivado con TRM (ganoCatalogWP.usdCop) ──
+window.ganoGetUsdCopRate = function () {
+  var w = typeof window !== 'undefined' ? window.ganoCatalogWP : null;
+  var r = w && Number(w.usdCop);
+  return r > 0 ? r : 4100;
 };
 
-// Formato auxiliar si necesitas precios completos (anuales)
-window.formatCOPFull = function(n) {
-  if (n == null) return '—';
-  return 'USD $' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+window.ganoCopFromUsd = function (usd) {
+  var u = Number(usd);
+  if (usd == null || isNaN(u)) return null;
+  return Math.round(u * window.ganoGetUsdCopRate());
+};
+
+/** Referencia USD desde monto catálogo (facturación típica en USD). */
+window.formatUSDRef = function (n) {
+  if (n == null || isNaN(Number(n))) return '—';
+  return 'USD $' + Number(n).toFixed(2) + '*';
+};
+
+/** COP aproximado desde monto USD del catálogo (TRM referencia). */
+window.formatCOPFromUsd = function (usd) {
+  var cop = window.ganoCopFromUsd(usd);
+  if (cop == null) return '—';
+  try {
+    return new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      maximumFractionDigits: 0,
+      minimumFractionDigits: 0,
+    }).format(cop);
+  } catch (e) {
+    return '$' + cop.toLocaleString('es-CO') + ' COP';
+  }
+};
+
+window.formatUSD = window.formatUSDRef;
+window.formatCOP = window.formatCOPFromUsd;
+
+window.formatCOPFull = function (usd) {
+  return window.formatCOPFromUsd(usd);
 };

--- a/wp-content/themes/gano-child/seo-pages/hosting-wordpress-colombia.php
+++ b/wp-content/themes/gano-child/seo-pages/hosting-wordpress-colombia.php
@@ -188,7 +188,7 @@ $landing_content_html = <<<'HTML'
             Migración gratuita incluida. Pagos por PSE, Nequi o tarjeta.
         </p>
         <div class="gano-cta-buttons">
-            <a href="/ecosistemas" class="gano-btn-primary" rel="noopener">
+            <a href="/ecosistemas/" class="gano-btn-primary" rel="noopener">
                 Ver todos los planes →
             </a>
             <a href="https://wa.me/57TUNUMERO?text=Hola%2C%20quiero%20hosting%20WordPress%20en%20Colombia"

--- a/wp-content/themes/gano-child/templates/page-comenzar-aqui.php
+++ b/wp-content/themes/gano-child/templates/page-comenzar-aqui.php
@@ -10,12 +10,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$url_shop      = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'shop-premium', 'tienda', 'catalogo' ) : home_url( '/shop-premium/' );
-$url_dominios  = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'dominios' ) : home_url( '/dominios/' );
-$url_contacto  = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'contacto' ) : home_url( '/contacto/' );
-$url_diag      = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'diagnostico-digital', 'diagnostico' ) : home_url( '/diagnostico-digital/' );
-$url_privacidad = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'privacidad', 'politica-de-privacidad' ) : home_url( '/privacidad/' );
-$url_terminos  = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'terminos', 'terminos-y-condiciones' ) : home_url( '/terminos/' );
+$url_shop        = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'shop-premium', 'tienda', 'catalogo' ) : home_url( '/shop-premium/' );
+$url_ecosistemas = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'ecosistemas' ) : home_url( '/ecosistemas/' );
+$url_dominios    = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'dominios' ) : home_url( '/dominios/' );
+$url_contacto    = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'contacto' ) : home_url( '/contacto/' );
+$url_diag        = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'diagnostico-digital', 'diagnostico' ) : home_url( '/diagnostico-digital/' );
+$url_privacidad  = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'privacidad', 'politica-de-privacidad' ) : home_url( '/privacidad/' );
+$url_terminos    = function_exists( 'gano_resolve_page_url' ) ? gano_resolve_page_url( 'terminos', 'terminos-y-condiciones' ) : home_url( '/terminos/' );
+
+/**
+ * URL del carrito con un plan de entrada (creación de cuenta en checkout GoDaddy).
+ * Si el PFID aún no está configurado, se usa el catálogo completo.
+ */
+$gano_cart_register_url = $url_ecosistemas;
+if ( function_exists( 'gano_rstore_cart_url' ) && defined( 'GANO_PFID_HOSTING_ECONOMIA' ) ) {
+	$gano_entry_pfid = constant( 'GANO_PFID_HOSTING_ECONOMIA' );
+	if ( is_string( $gano_entry_pfid ) && '' !== $gano_entry_pfid && 'PENDING_RCC' !== $gano_entry_pfid ) {
+		$gano_try_cart = gano_rstore_cart_url( $gano_entry_pfid, 12 );
+		if ( is_string( $gano_try_cart ) && '' !== $gano_try_cart && '#' !== $gano_try_cart ) {
+			$gano_cart_register_url = $gano_try_cart;
+		}
+	}
+}
 
 $faq_schema = array(
 	'@context'   => 'https://schema.org',
@@ -42,7 +58,7 @@ $faq_schema = array(
 			'name'           => __( '¿Los precios están en pesos colombianos (COP)?', 'gano-child' ),
 			'acceptedAnswer' => array(
 				'@type' => 'Answer',
-				'text'  => __( 'El catálogo está pensado para operación en COP. En el carrito, verifica que la moneda mostrada sea la esperada antes de confirmar.', 'gano-child' ),
+				'text'  => __( 'En gano.digital verás referencia en COP y USD. El cobro lo confirma el carrito GoDaddy Reseller; revisa moneda y total antes de pagar.', 'gano-child' ),
 			),
 		),
 		array(
@@ -77,37 +93,53 @@ get_header();
 
 <main id="gano-main-content" class="gano-start-journey gano-trust-page gano-km-shell gano-on-dark" data-gano-start-journey>
 
-	<section class="gano-start-journey__hero" aria-label="<?php esc_attr_e( 'Guía de compra', 'gano-child' ); ?>">
+	<section class="gano-start-journey__hero" id="registro-checkout" aria-label="<?php esc_attr_e( 'Guía de compra y registro', 'gano-child' ); ?>">
 		<div class="gano-km-container">
 			<div class="gano-km-hero">
-				<div>
+				<div class="gano-start-journey__hero-main">
 					<p class="gano-km-live-badge"><?php esc_html_e( 'Guía de compra', 'gano-child' ); ?></p>
 					<h1 class="gano-km-title">
 						<?php esc_html_e( 'Compra con claridad', 'gano-child' ); ?>
 						<span class="gano-km-title-accent"><?php esc_html_e( 'sin sorpresas', 'gano-child' ); ?></span>
 					</h1>
 					<p class="gano-km-lead">
-						<?php esc_html_e( 'Te explicamos el flujo real: eliges en gano.digital y el pago ocurre en el carrito GoDaddy Reseller (marca blanca). Así entiendes qué pasa, dónde se cobra y qué hacemos nosotros después.', 'gano-child' ); ?>
+						<?php esc_html_e( 'Tu cuenta de cliente del producto se crea en el checkout de GoDaddy Reseller (marca blanca), no en un formulario oculto de esta web. Elige plan aquí, abre el carrito y allí registras correo, facturación y pago con total transparencia.', 'gano-child' ); ?>
 					</p>
-					<div class="gano-km-cta-row">
-						<a class="gano-km-btn-primary" href="<?php echo esc_url( $url_shop ); ?>"><?php esc_html_e( 'Ir al catálogo', 'gano-child' ); ?></a>
-						<a class="gano-km-btn-secondary" href="<?php echo esc_url( $url_contacto ); ?>"><?php esc_html_e( 'Hablar con el equipo', 'gano-child' ); ?></a>
+					<ol class="gano-start-journey__register-track" aria-label="<?php esc_attr_e( 'Pasos para registrarte y comprar', 'gano-child' ); ?>">
+						<li>
+							<span class="gano-start-journey__register-track-step"><?php esc_html_e( 'Paso 1', 'gano-child' ); ?></span>
+							<span class="gano-start-journey__register-track-text"><?php esc_html_e( 'Abre el carrito con un plan (o elige otro en el catálogo).', 'gano-child' ); ?></span>
+						</li>
+						<li>
+							<span class="gano-start-journey__register-track-step"><?php esc_html_e( 'Paso 2', 'gano-child' ); ?></span>
+							<span class="gano-start-journey__register-track-text"><?php esc_html_e( 'En cart.secureserver.net crea tu cuenta o inicia sesión.', 'gano-child' ); ?></span>
+						</li>
+						<li>
+							<span class="gano-start-journey__register-track-step"><?php esc_html_e( 'Paso 3', 'gano-child' ); ?></span>
+							<span class="gano-start-journey__register-track-text"><?php esc_html_e( 'Confirma moneda e importe; al pagar, activamos soporte Gano.', 'gano-child' ); ?></span>
+						</li>
+					</ol>
+					<div class="gano-km-cta-row gano-start-journey__hero-ctas">
+						<a class="gano-km-btn-primary" href="<?php echo esc_url( $gano_cart_register_url ); ?>" rel="noopener noreferrer"><?php esc_html_e( 'Crear cuenta en el checkout', 'gano-child' ); ?></a>
+						<a class="gano-km-btn-secondary" href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Ver catálogo completo', 'gano-child' ); ?></a>
+						<a class="gano-km-btn-secondary gano-start-journey__cta-quiet" href="<?php echo esc_url( $url_contacto ); ?>"><?php esc_html_e( 'Hablar con el equipo', 'gano-child' ); ?></a>
 					</div>
 					<p class="gano-start-journey__microcopy">
-						<?php esc_html_e( 'Tip: si es tu primera compra, revisa el checklist a la derecha antes de abrir el carrito.', 'gano-child' ); ?>
+						<?php esc_html_e( 'Tip: revisa el checklist (al lado en escritorio, debajo en móvil) antes de pagar. El botón principal te lleva al carrito seguro donde se completa el registro.', 'gano-child' ); ?>
 					</p>
 				</div>
 
 				<aside class="gano-start-journey__glass" aria-label="<?php esc_attr_e( 'Checklist antes de pagar', 'gano-child' ); ?>">
 					<h2 class="gano-start-journey__glass-title"><?php esc_html_e( 'Antes de pagar', 'gano-child' ); ?></h2>
 					<ul class="gano-start-journey__checklist">
-						<li><?php esc_html_e( 'Verifica moneda (COP) y plan seleccionado.', 'gano-child' ); ?></li>
+						<li><?php esc_html_e( 'Verifica moneda (COP / USD) y el plan en el resumen del carrito.', 'gano-child' ); ?></li>
 						<li><?php esc_html_e( 'El pago ocurre en GoDaddy Reseller (carrito marca blanca).', 'gano-child' ); ?></li>
 						<li><?php esc_html_e( 'Gano Digital no almacena datos de tarjeta.', 'gano-child' ); ?></li>
 						<li><?php esc_html_e( 'Si algo no cuadra, para y escríbenos.', 'gano-child' ); ?></li>
 					</ul>
 					<div class="gano-start-journey__glass-cta">
-						<a class="gano-km-btn-secondary" href="#comenzar-compra-ahora"><?php esc_html_e( 'Ver pasos', 'gano-child' ); ?></a>
+						<a class="gano-km-btn-primary" href="<?php echo esc_url( $gano_cart_register_url ); ?>" rel="noopener noreferrer"><?php esc_html_e( 'Ir al checkout', 'gano-child' ); ?></a>
+						<a class="gano-km-btn-secondary" href="#comenzar-compra-ahora"><?php esc_html_e( 'Ver más abajo', 'gano-child' ); ?></a>
 						<a class="gano-km-btn-tertiary" href="<?php echo esc_url( $url_contacto ); ?>"><?php esc_html_e( 'Resolver dudas', 'gano-child' ); ?></a>
 					</div>
 				</aside>
@@ -119,7 +151,7 @@ get_header();
 		<div class="gano-km-container">
 			<h2 id="gano-start-trust-heading" class="screen-reader-text"><?php esc_html_e( 'Por qué comprar con este flujo', 'gano-child' ); ?></h2>
 			<ul class="gano-start-journey__trust-list">
-				<li><strong><?php esc_html_e( 'COP', 'gano-child' ); ?></strong><span><?php esc_html_e( 'Operación comercial local', 'gano-child' ); ?></span></li>
+				<li><strong><?php esc_html_e( 'COP + USD*', 'gano-child' ); ?></strong><span><?php esc_html_e( 'Referencia en sitio; cobro según carrito', 'gano-child' ); ?></span></li>
 				<li><strong><?php esc_html_e( 'Checkout GoDaddy', 'gano-child' ); ?></strong><span><?php esc_html_e( 'Pago en operador autorizado', 'gano-child' ); ?></span></li>
 				<li><strong><?php esc_html_e( 'Sin tarjeta en Gano', 'gano-child' ); ?></strong><span><?php esc_html_e( 'No almacenamos datos de pago', 'gano-child' ); ?></span></li>
 				<li><strong><?php esc_html_e( 'Soporte real', 'gano-child' ); ?></strong><span><?php esc_html_e( 'Español, contexto WordPress', 'gano-child' ); ?></span></li>
@@ -140,7 +172,9 @@ get_header();
 						<?php esc_html_e( 'En el catálogo SOTA comparas planes (hosting, seguridad, add-ons). Los precios mostrados están pensados para orientar; el detalle final lo confirma el carrito.', 'gano-child' ); ?>
 					</p>
 					<p class="gano-start-journey__step-link">
-						<a href="<?php echo esc_url( $url_shop ); ?>"><?php esc_html_e( 'Abrir catálogo →', 'gano-child' ); ?></a>
+						<a href="<?php echo esc_url( $gano_cart_register_url ); ?>" rel="noopener noreferrer"><?php esc_html_e( 'Abrir carrito (registro) →', 'gano-child' ); ?></a>
+						&nbsp;·&nbsp;
+						<a href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Catálogo Ecosistemas →', 'gano-child' ); ?></a>
 						&nbsp;·&nbsp;
 						<a href="<?php echo esc_url( $url_dominios ); ?>"><?php esc_html_e( 'Dominios →', 'gano-child' ); ?></a>
 					</p>
@@ -148,7 +182,7 @@ get_header();
 				<li>
 					<h3><?php esc_html_e( '2. Checkout seguro (fuera de gano.digital)', 'gano-child' ); ?></h3>
 					<p>
-						<?php esc_html_e( 'Al pulsar adquirir, el navegador abre el carrito GoDaddy Reseller. Ahí creas o usas cuenta, facturación y método de pago. Ese entorno es quien tokeniza y procesa el cobro — no una pasarela improvisada en nuestro WordPress.', 'gano-child' ); ?>
+						<?php esc_html_e( 'Al continuar, el navegador abre el carrito GoDaddy Reseller. Ahí es donde se crea tu cuenta de cliente (correo y contraseña del operador), datos de facturación y método de pago. Ese entorno tokeniza y cobra; Gano Digital no clona ese registro en WordPress.', 'gano-child' ); ?>
 					</p>
 				</li>
 				<li>
@@ -167,8 +201,11 @@ get_header();
 			<div class="gano-start-journey__paths">
 				<article class="gano-start-journey__path gano-start-journey__path--primary">
 					<h3><?php esc_html_e( 'Ya sé qué necesito', 'gano-child' ); ?></h3>
-					<p><?php esc_html_e( 'Ve al catálogo, filtra por categoría y pulsa adquirir en el plan correcto. Si el botón está pendiente de configuración, no fuerces el flujo: contáctanos.', 'gano-child' ); ?></p>
-					<a class="gano-km-btn-primary" href="<?php echo esc_url( $url_shop ); ?>"><?php esc_html_e( 'Ir al catálogo', 'gano-child' ); ?></a>
+					<p><?php esc_html_e( 'Usa el checkout con plan de entrada o abre el catálogo completo y pulsa “Contratar” en el plan que necesites. Si ves “configuración pendiente”, no fuerces el flujo: escríbenos.', 'gano-child' ); ?></p>
+					<p class="gano-start-journey__path-row gano-start-journey__path-row--stack">
+						<a class="gano-km-btn-primary" href="<?php echo esc_url( $gano_cart_register_url ); ?>" rel="noopener noreferrer"><?php esc_html_e( 'Checkout y registro', 'gano-child' ); ?></a>
+						<a class="gano-km-btn-secondary" href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Catálogo Ecosistemas', 'gano-child' ); ?></a>
+					</p>
 				</article>
 				<article class="gano-start-journey__path">
 					<h3><?php esc_html_e( 'Quiero validar antes de pagar', 'gano-child' ); ?></h3>
@@ -184,10 +221,10 @@ get_header();
 
 	<?php
 	gano_cta_registro(array(
-		'heading'     => '¿No sabes cuál es el siguiente paso?',
-		'description' => 'Registra tu cuenta y accede al catálogo con soporte en español. Aquí comenzamos tu viaje.',
-		'button_text' => 'Comenzar ahora',
-		'button_url'  => $url_shop,
+		'heading'     => __( '¿Listo para crear tu cuenta en el checkout?', 'gano-child' ),
+		'description' => __( 'Un clic te lleva al carrito seguro de GoDaddy Reseller: allí eliges método de pago y completas el registro de cliente. Luego te acompañamos en activación y soporte.', 'gano-child' ),
+		'button_text' => __( 'Ir al checkout y registrarme', 'gano-child' ),
+		'button_url'  => $gano_cart_register_url,
 	));
 	?>
 
@@ -210,7 +247,7 @@ get_header();
 
 			<details class="gano-start-journey__details">
 				<summary><?php esc_html_e( '¿Los precios están en pesos colombianos (COP)?', 'gano-child' ); ?></summary>
-				<p><?php esc_html_e( 'El sitio está orientado a operación en COP. En el carrito, confirma la moneda antes de pagar.', 'gano-child' ); ?></p>
+				<p><?php esc_html_e( 'En gano.digital mostramos referencia en COP y USD. La moneda definitiva y el total los confirma el carrito GoDaddy antes de pagar.', 'gano-child' ); ?></p>
 			</details>
 
 			<details class="gano-start-journey__details">
@@ -235,7 +272,8 @@ get_header();
 				<?php esc_html_e( 'El mejor momento para mejorar tu infraestructura es cuando ya entiendes qué estás comprando. Si es tu caso, el catálogo te espera.', 'gano-child' ); ?>
 			</p>
 			<p class="gano-start-journey__hero-cta">
-				<a class="gano-km-btn-primary" href="<?php echo esc_url( $url_shop ); ?>"><?php esc_html_e( 'Comprar en el catálogo', 'gano-child' ); ?></a>
+				<a class="gano-km-btn-primary" href="<?php echo esc_url( $gano_cart_register_url ); ?>" rel="noopener noreferrer"><?php esc_html_e( 'Checkout: crear cuenta y pagar', 'gano-child' ); ?></a>
+				<a class="gano-km-btn-secondary" href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Explorar todos los planes', 'gano-child' ); ?></a>
 				<a class="gano-km-btn-secondary" href="<?php echo esc_url( $url_contacto ); ?>"><?php esc_html_e( 'Prefiero asesoría humana', 'gano-child' ); ?></a>
 			</p>
 		</div>

--- a/wp-content/themes/gano-child/templates/page-contacto.php
+++ b/wp-content/themes/gano-child/templates/page-contacto.php
@@ -114,7 +114,7 @@ get_header(); ?>
 
         <p class="gano-contacto__cta-link">
           ¿Ya sabes qué necesitas?<br>
-          <a href="/ecosistemas">Ver planes y precios →</a>
+          <a href="/ecosistemas/">Ver planes y precios →</a>
         </p>
       </aside>
 

--- a/wp-content/themes/gano-child/templates/page-nosotros.php
+++ b/wp-content/themes/gano-child/templates/page-nosotros.php
@@ -113,7 +113,7 @@ get_header(); ?>
       <p class="gano-nosotros__cta-copy">Habla con el equipo. Sin formularios de ventas agresivos.</p>
       <a href="/contacto" class="gano-btn">Habla con el equipo</a>
       &nbsp;&nbsp;
-      <a href="/ecosistemas" class="gano-nosotros__cta-link">Ver ecosistemas →</a>
+      <a href="/ecosistemas/" class="gano-nosotros__cta-link">Ver ecosistemas →</a>
     </div>
   </section>
 

--- a/wp-content/themes/gano-child/templates/shop-premium.php
+++ b/wp-content/themes/gano-child/templates/shop-premium.php
@@ -4,24 +4,39 @@
  *
  * Este template renderiza el catálogo SOTA de forma agnóstica utilizando
  * el motor React-like (catalog-sota.js) que consume reseller-data.js.
+ *
+ * TRM COP/USD: opción `gano_usd_cop_rate` o filtro `gano_catalog_usd_cop_rate`.
  */
+
+$gano_usd_cop_rate = (float) apply_filters(
+	'gano_catalog_usd_cop_rate',
+	(float) get_option( 'gano_usd_cop_rate', 4100 )
+);
+if ( $gano_usd_cop_rate <= 0 ) {
+	$gano_usd_cop_rate = 4100;
+}
 
 // Enqueue catalog assets specific to this template BEFORE get_header()
 wp_enqueue_style( 'gano-fonts-sota', 'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Manrope:wght@400;500;600&display=swap', array(), null );
-wp_enqueue_style( 'gano-catalog-sota-css', get_stylesheet_directory_uri() . '/css/catalog-sota.css', array(), '1.0.0' );
+wp_enqueue_style( 'gano-catalog-sota-css', get_stylesheet_directory_uri() . '/css/catalog-sota.css', array(), '1.1.0' );
 
 // Load font-awesome if not loaded
 wp_enqueue_style( 'font-awesome-6', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css', array(), '6.5.0' );
 
 // Enqueue data and logic
-wp_enqueue_script( 'gano-reseller-data', get_stylesheet_directory_uri() . '/js/reseller-data.js', array(), '1.0.0', true );
-wp_enqueue_script( 'gano-catalog-sota-js', get_stylesheet_directory_uri() . '/js/catalog-sota.js', array('gano-reseller-data'), '1.0.0', true );
+wp_enqueue_script( 'gano-reseller-data', get_stylesheet_directory_uri() . '/js/reseller-data.js', array(), '1.1.0', true );
+wp_enqueue_script( 'gano-catalog-sota-js', get_stylesheet_directory_uri() . '/js/catalog-sota.js', array( 'gano-reseller-data' ), '1.1.0', true );
 
 // Pass PHP config variables to JS if needed
-wp_localize_script( 'gano-reseller-data', 'ganoCatalogWP', array(
-    'ajaxurl' => admin_url( 'admin-ajax.php' ),
-    'whatsappNum' => '573000000000'
-));
+wp_localize_script(
+	'gano-reseller-data',
+	'ganoCatalogWP',
+	array(
+		'ajaxurl'     => admin_url( 'admin-ajax.php' ),
+		'whatsappNum' => '573000000000',
+		'usdCop'      => $gano_usd_cop_rate,
+	)
+);
 
 get_header();
 ?>
@@ -34,7 +49,7 @@ get_header();
       <div class="container">
         <div class="hero-eyebrow"><i class="fa-solid fa-shield-halved"></i> Infraestructura SOTA · Nodo Bogotá</div>
         <h1>Tu soberanía digital<br><span class="accent">sin concesiones</span></h1>
-        <p class="hero-sub">Hosting WordPress NVMe, VPS dedicado, dominios .co y seguridad de capa 7. Todo en COP, soporte en español, datos en Colombia.</p>
+        <p class="hero-sub">Hosting WordPress NVMe, VPS dedicado, dominios .co y seguridad de capa 7. Referencia en COP y USD* según catálogo; soporte en español.</p>
         <div class="hero-stats">
           <div class="hero-stat"><span class="stat-val">99.99%</span><span class="stat-lbl">SLA Elite</span></div>
           <div class="stat-div"></div>
@@ -72,6 +87,17 @@ get_header();
               <div class="results-bar">
                 <span class="rcount">Mostrando <strong id="results-count">0</strong> productos</span>
               </div>
+              <p class="catalog-price-disclaimer">
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: COP per 1 USD (integer reference rate). */
+						__( '*COP estimado con TRM de referencia (%s COP/USD). La facturación del proveedor puede aplicarse en USD; el tipo al momento del cobro puede variar.', 'gano-child' ),
+						number_format_i18n( $gano_usd_cop_rate, 0 )
+					)
+				);
+				?>
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Resumen
- **Atlas de lectura:** shortcode `[gano_content_atlas]`, chips, sheet móvil, runbook Elementor (home 1745).
- **Catálogo SOTA (Ecosistemas / shop-premium):** precios en **COP + referencia USD*** con TRM `gano_usd_cop_rate` / filtro `gano_catalog_usd_cop_rate`, disclaimer legal, helpers en `reseller-data.js`, bloque dual en `catalog-sota.js`.
- **Landing (`front-page.php`):** eliminado grid con `[rstore_product]` (teaser naranja Reseller). Teaser conservado en borrador: `inc/draft-home-rstore-catalog-home.php` + filtro `gano_show_draft_home_rstore_catalog`. Sección comercial mínima con CTAs a `/ecosistemas/` y shop-premium.
- **Enqueue:** `gano-catalog-intelligence` ya no se carga en home (no hay `[data-gano-catalog]` en portada).
- **Comenzar aquí:** CTAs al carrito (`gano_rstore_cart_url`), contraste y FAQ/schema; `gano-start-journey.css`.
- **Varios:** `gano-catalog-intelligence.js` (encoding, enlaces con `/`), enlaces `/ecosistemas/`, chips catálogo alineados a mockup (píldoras lilac).

## Servidor (contexto previo)
- Publicados borradores de páginas donde aplicaba; menú principal Blog + Comenzar aquí; menú legacy ID 4 eliminado.

## Archivos clave
- `inc/gano-content-atlas.php`, `inc/draft-home-rstore-catalog-home.php`
- `front-page.php`, `functions.php`, `css/homepage.css`, `css/catalog-sota.css`, `css/gano-start-journey.css`
- `templates/shop-premium.php`, `js/catalog-sota.js`, `js/reseller-data.js`
- `templates/page-comenzar-aqui.php`
- `memory/ops/*` (auditoría + runbook Atlas)

## Pendiente humano
- Pegar `[gano_content_atlas]` en Elementor en página Inicio si aún no está (runbook).
- Revisar CI (php-lint, TruffleHog).
- **Catálogo mockup:** cabeceras por familia + contadores tipo mockup (`mockup_completo_ignorar.html`) — siguiente iteración en `catalog-sota.js` / plantilla.

## Checklist
- [x] `php -l` en PHP tocados
- [x] Sin `git add` de `wiki/` ni secretos

Made with [Cursor](https://cursor.com)