### PR TITLE
feat(landing): landing SOTA v2 dark — reemplazo front-page.php

### DIFF
--- a/wp-content/themes/gano-child/css/landing-sota-v2.css
+++ b/wp-content/themes/gano-child/css/landing-sota-v2.css
@@ -1,0 +1,1111 @@
+/* ============================================================================
+   GANO DIGITAL — LANDING SOTA V2
+   Scoped to .gano-landing-sota to avoid collisions with parent theme.
+   Extracted from gano-digital-landing.html
+   ========================================================================== */
+
+:root {
+  --bg-void: #050508;
+  --bg-surface: #0a0a0f;
+  --bg-elevated: #111118;
+  --bg-card: #16161f;
+  --border-subtle: #1e1e2e;
+  --border-default: #2a2a3e;
+  --border-active: #3a3a52;
+  --text-primary: #f0f0f5;
+  --text-secondary: #a0a0b0;
+  --text-muted: #606070;
+  --accent-cyan: #00d4aa;
+  --accent-cyan-dim: #00a884;
+  --accent-blue: #3b82f6;
+  --accent-amber: #f59e0b;
+  --accent-red: #ef4444;
+  --gradient-hero: linear-gradient(135deg, #00d4aa 0%, #3b82f6 100%);
+  --gradient-glow: radial-gradient(ellipse at center, rgba(0,212,170,0.15) 0%, transparent 70%);
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --shadow-glow: 0 0 40px rgba(0,212,170,0.1);
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px;
+}
+
+.gano-landing-sota,
+.gano-landing-sota *,
+.gano-landing-sota *::before,
+.gano-landing-sota *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.gano-landing-sota {
+  font-family: var(--font-sans);
+  background: var(--bg-void);
+  color: var(--text-primary);
+  line-height: 1.6;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.gano-landing-sota ::selection {
+  background: rgba(0,212,170,0.3);
+  color: var(--text-primary);
+}
+
+.gano-landing-sota::-webkit-scrollbar {
+  width: 8px;
+}
+.gano-landing-sota::-webkit-scrollbar-track {
+  background: var(--bg-void);
+}
+.gano-landing-sota::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: 4px;
+}
+.gano-landing-sota::-webkit-scrollbar-thumb:hover {
+  background: var(--border-active);
+}
+
+/* ---- UTILITY ---- */
+.gano-landing-sota .container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+.gano-landing-sota .container-narrow {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.gano-landing-sota .gradient-text {
+  background: var(--gradient-hero);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.gano-landing-sota .mono {
+  font-family: var(--font-mono);
+}
+
+.gano-landing-sota .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 100px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+.gano-landing-sota .badge-accent {
+  border-color: rgba(0,212,170,0.3);
+  background: rgba(0,212,170,0.08);
+  color: var(--accent-cyan);
+}
+
+/* ---- ANIMATIONS ---- */
+@keyframes gano-fadeInUp {
+  from { opacity: 0; transform: translateY(30px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes gano-fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes gano-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+@keyframes gano-float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+@keyframes gano-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+@keyframes gano-gridMove {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(40px); }
+}
+@keyframes gano-spin-slow {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.gano-landing-sota .animate-in {
+  animation: gano-fadeInUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  opacity: 0;
+}
+.gano-landing-sota .delay-1 { animation-delay: 0.1s; }
+.gano-landing-sota .delay-2 { animation-delay: 0.2s; }
+.gano-landing-sota .delay-3 { animation-delay: 0.3s; }
+.gano-landing-sota .delay-4 { animation-delay: 0.4s; }
+.gano-landing-sota .delay-5 { animation-delay: 0.5s; }
+
+/* ---- NAVIGATION ---- */
+.gano-landing-sota .nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  padding: 16px 0;
+  transition: all 0.3s ease;
+  border-bottom: 1px solid transparent;
+}
+.gano-landing-sota .nav.scrolled {
+  background: rgba(5,5,8,0.85);
+  backdrop-filter: blur(20px);
+  border-bottom-color: var(--border-subtle);
+  padding: 12px 0;
+}
+.gano-landing-sota .nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.gano-landing-sota .nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--text-primary);
+  font-weight: 800;
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+}
+.gano-landing-sota .nav-logo-icon {
+  width: 36px;
+  height: 36px;
+  background: var(--gradient-hero);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+.gano-landing-sota .nav-links {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  list-style: none;
+}
+.gano-landing-sota .nav-links a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: color 0.2s;
+  position: relative;
+}
+.gano-landing-sota .nav-links a:hover {
+  color: var(--text-primary);
+}
+.gano-landing-sota .nav-links a::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--accent-cyan);
+  transition: width 0.3s;
+}
+.gano-landing-sota .nav-links a:hover::after {
+  width: 100%;
+}
+.gano-landing-sota .nav-cta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.gano-landing-sota .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 24px;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+.gano-landing-sota .btn-primary {
+  background: var(--gradient-hero);
+  color: #000;
+  box-shadow: 0 4px 20px rgba(0,212,170,0.3);
+}
+.gano-landing-sota .btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(0,212,170,0.4);
+}
+.gano-landing-sota .btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+}
+.gano-landing-sota .btn-ghost:hover {
+  border-color: var(--border-active);
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+.gano-landing-sota .btn-lg {
+  padding: 14px 32px;
+  font-size: 1rem;
+}
+
+.gano-landing-sota .mobile-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+/* ---- HERO ---- */
+.gano-landing-sota .hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  padding: 140px 0 100px;
+  overflow: hidden;
+}
+.gano-landing-sota .hero-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+.gano-landing-sota .hero-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(0,212,170,0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,170,0.03) 1px, transparent 1px);
+  background-size: 60px 60px;
+  animation: gano-gridMove 20s linear infinite;
+  mask-image: radial-gradient(ellipse at center, black 30%, transparent 70%);
+}
+.gano-landing-sota .hero-glow {
+  position: absolute;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 800px;
+  height: 600px;
+  background: var(--gradient-glow);
+  pointer-events: none;
+}
+.gano-landing-sota .hero-particles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+.gano-landing-sota .particle {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  background: var(--accent-cyan);
+  border-radius: 50%;
+  opacity: 0.3;
+  animation: gano-float 6s ease-in-out infinite;
+}
+
+.gano-landing-sota .hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+}
+.gano-landing-sota .hero-badge {
+  margin-bottom: 24px;
+}
+.gano-landing-sota .hero-title {
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-weight: 900;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  margin-bottom: 24px;
+}
+.gano-landing-sota .hero-title .line {
+  display: block;
+}
+.gano-landing-sota .hero-subtitle {
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  color: var(--text-secondary);
+  max-width: 560px;
+  margin-bottom: 40px;
+  line-height: 1.7;
+}
+.gano-landing-sota .hero-ctas {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 48px;
+}
+.gano-landing-sota .hero-trust {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.gano-landing-sota .trust-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+.gano-landing-sota .trust-item i {
+  color: var(--accent-cyan);
+  font-size: 1rem;
+}
+
+.gano-landing-sota .hero-visual {
+  position: absolute;
+  right: -5%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 550px;
+  height: 550px;
+  z-index: 1;
+  pointer-events: none;
+}
+.gano-landing-sota .server-rack {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+.gano-landing-sota .rack-unit {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 280px;
+  height: 50px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  gap: 12px;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.5);
+}
+.gano-landing-sota .rack-unit::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-cyan);
+  box-shadow: 0 0 10px var(--accent-cyan);
+  animation: gano-pulse 2s infinite;
+}
+.gano-landing-sota .rack-unit .bar {
+  flex: 1;
+  height: 4px;
+  background: var(--border-subtle);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.gano-landing-sota .rack-unit .bar-fill {
+  height: 100%;
+  background: var(--gradient-hero);
+  border-radius: 2px;
+  animation: gano-shimmer 3s infinite;
+  background-size: 200% 100%;
+}
+.gano-landing-sota .rack-unit:nth-child(1) { top: 15%; }
+.gano-landing-sota .rack-unit:nth-child(2) { top: 30%; }
+.gano-landing-sota .rack-unit:nth-child(3) { top: 45%; }
+.gano-landing-sota .rack-unit:nth-child(4) { top: 60%; }
+.gano-landing-sota .rack-unit:nth-child(5) { top: 75%; }
+
+.gano-landing-sota .connection-lines {
+  position: absolute;
+  inset: 0;
+}
+.gano-landing-sota .conn-line {
+  position: absolute;
+  width: 2px;
+  background: linear-gradient(to bottom, transparent, var(--accent-cyan), transparent);
+  opacity: 0.2;
+}
+
+/* ---- SECTIONS ---- */
+.gano-landing-sota .section {
+  padding: 100px 0;
+  position: relative;
+}
+.gano-landing-sota .section-header {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto 64px;
+}
+.gano-landing-sota .section-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent-cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: 16px;
+}
+.gano-landing-sota .section-title {
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 16px;
+  line-height: 1.2;
+}
+.gano-landing-sota .section-desc {
+  color: var(--text-secondary);
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+/* ---- SOTA BANNER ---- */
+.gano-landing-sota .sota-banner {
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 60px 0;
+}
+.gano-landing-sota .sota-inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: center;
+}
+.gano-landing-sota .sota-text h3 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+.gano-landing-sota .sota-text p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  font-size: 1rem;
+}
+.gano-landing-sota .sota-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.gano-landing-sota .sota-stat {
+  text-align: center;
+  padding: 24px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+.gano-landing-sota .sota-stat-value {
+  font-family: var(--font-mono);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--accent-cyan);
+  margin-bottom: 4px;
+}
+.gano-landing-sota .sota-stat-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ---- PILARS ---- */
+.gano-landing-sota .pillars-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+}
+.gano-landing-sota .pillar-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+.gano-landing-sota .pillar-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--gradient-hero);
+  transform: scaleX(0);
+  transition: transform 0.3s;
+}
+.gano-landing-sota .pillar-card:hover {
+  border-color: var(--border-active);
+  transform: translateY(-4px);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+}
+.gano-landing-sota .pillar-card:hover::before {
+  transform: scaleX(1);
+}
+.gano-landing-sota .pillar-icon {
+  width: 48px;
+  height: 48px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  color: var(--accent-cyan);
+  margin-bottom: 20px;
+}
+.gano-landing-sota .pillar-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.gano-landing-sota .pillar-desc {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ---- PRICING ---- */
+.gano-landing-sota .pricing-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 48px;
+}
+.gano-landing-sota .pricing-tab {
+  padding: 10px 24px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+.gano-landing-sota .pricing-tab.active {
+  background: var(--bg-card);
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+.gano-landing-sota .pricing-tab:hover:not(.active) {
+  border-color: var(--border-active);
+  color: var(--text-primary);
+}
+
+.gano-landing-sota .pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+.gano-landing-sota .pricing-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 40px 32px;
+  position: relative;
+  transition: all 0.3s;
+}
+.gano-landing-sota .pricing-card:hover {
+  border-color: var(--border-active);
+  transform: translateY(-4px);
+}
+.gano-landing-sota .pricing-card.featured {
+  border-color: var(--accent-cyan);
+  box-shadow: var(--shadow-glow);
+  transform: scale(1.02);
+}
+.gano-landing-sota .pricing-card.featured:hover {
+  transform: scale(1.02) translateY(-4px);
+}
+.gano-landing-sota .pricing-badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--gradient-hero);
+  color: #000;
+  padding: 4px 16px;
+  border-radius: 100px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.gano-landing-sota .pricing-name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.gano-landing-sota .pricing-desc {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin-bottom: 24px;
+}
+.gano-landing-sota .pricing-price {
+  margin-bottom: 24px;
+}
+.gano-landing-sota .pricing-price .currency {
+  font-size: 1.5rem;
+  font-weight: 700;
+  vertical-align: top;
+  line-height: 1;
+}
+.gano-landing-sota .pricing-price .amount {
+  font-size: 3.5rem;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+.gano-landing-sota .pricing-price .period {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+.gano-landing-sota .pricing-price .usd {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.gano-landing-sota .pricing-features {
+  list-style: none;
+  margin-bottom: 32px;
+}
+.gano-landing-sota .pricing-features li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.gano-landing-sota .pricing-features li:last-child {
+  border-bottom: none;
+}
+.gano-landing-sota .pricing-features li i {
+  color: var(--accent-cyan);
+  font-size: 0.75rem;
+}
+.gano-landing-sota .pricing-features li.muted {
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+.gano-landing-sota .pricing-features li.muted i {
+  color: var(--text-muted);
+}
+
+/* ---- DOMAIN SEARCH ---- */
+.gano-landing-sota .domain-section {
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.gano-landing-sota .domain-box {
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 48px;
+  text-align: center;
+}
+.gano-landing-sota .domain-search {
+  display: flex;
+  gap: 12px;
+  max-width: 600px;
+  margin: 32px auto 0;
+}
+.gano-landing-sota .domain-input {
+  flex: 1;
+  padding: 14px 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s;
+}
+.gano-landing-sota .domain-input:focus {
+  border-color: var(--accent-cyan);
+}
+.gano-landing-sota .domain-input::placeholder {
+  color: var(--text-muted);
+}
+.gano-landing-sota .domain-tlds {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+.gano-landing-sota .tld-tag {
+  padding: 6px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.gano-landing-sota .tld-tag .price {
+  color: var(--accent-cyan);
+  margin-left: 6px;
+}
+
+/* ---- TESTIMONIALS ---- */
+.gano-landing-sota .testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.gano-landing-sota .testimonial-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  position: relative;
+}
+.gano-landing-sota .testimonial-card::before {
+  content: '"';
+  position: absolute;
+  top: 16px;
+  right: 24px;
+  font-size: 4rem;
+  color: var(--border-default);
+  font-family: Georgia, serif;
+  line-height: 1;
+}
+.gano-landing-sota .testimonial-text {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 24px;
+  position: relative;
+  z-index: 1;
+}
+.gano-landing-sota .testimonial-author {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.gano-landing-sota .testimonial-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--gradient-hero);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: #000;
+}
+.gano-landing-sota .testimonial-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+.gano-landing-sota .testimonial-role {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+.gano-landing-sota .stars {
+  color: var(--accent-amber);
+  font-size: 0.8rem;
+  margin-bottom: 12px;
+}
+
+/* ---- SERVICES ---- */
+.gano-landing-sota .services-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.gano-landing-sota .service-row {
+  display: grid;
+  grid-template-columns: 60px 1fr auto;
+  gap: 24px;
+  align-items: center;
+  padding: 28px 32px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition: all 0.3s;
+  cursor: pointer;
+}
+.gano-landing-sota .service-row:hover {
+  border-color: var(--border-active);
+  background: var(--bg-elevated);
+}
+.gano-landing-sota .service-icon {
+  width: 48px;
+  height: 48px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  color: var(--accent-cyan);
+}
+.gano-landing-sota .service-info h4 {
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.gano-landing-sota .service-info p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+.gano-landing-sota .service-arrow {
+  color: var(--text-muted);
+  transition: color 0.2s, transform 0.2s;
+}
+.gano-landing-sota .service-row:hover .service-arrow {
+  color: var(--accent-cyan);
+  transform: translateX(4px);
+}
+
+/* ---- NEWSLETTER ---- */
+.gano-landing-sota .newsletter-box {
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: 64px 48px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.gano-landing-sota .newsletter-box::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--gradient-hero);
+}
+.gano-landing-sota .newsletter-form {
+  display: flex;
+  gap: 12px;
+  max-width: 480px;
+  margin: 32px auto 0;
+}
+.gano-landing-sota .newsletter-input {
+  flex: 1;
+  padding: 14px 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  font-family: inherit;
+  outline: none;
+}
+.gano-landing-sota .newsletter-input:focus {
+  border-color: var(--accent-cyan);
+}
+
+/* ---- FOOTER ---- */
+.gano-landing-sota .footer {
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-subtle);
+  padding: 80px 0 40px;
+}
+.gano-landing-sota .footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 48px;
+  margin-bottom: 64px;
+}
+.gano-landing-sota .footer-brand {
+  max-width: 300px;
+}
+.gano-landing-sota .footer-brand .logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  font-size: 1.25rem;
+  margin-bottom: 16px;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+.gano-landing-sota .footer-brand p {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+.gano-landing-sota .footer-col h4 {
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  margin-bottom: 20px;
+}
+.gano-landing-sota .footer-col ul {
+  list-style: none;
+}
+.gano-landing-sota .footer-col li {
+  margin-bottom: 10px;
+}
+.gano-landing-sota .footer-col a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+.gano-landing-sota .footer-col a:hover {
+  color: var(--accent-cyan);
+}
+.gano-landing-sota .footer-bottom {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.gano-landing-sota .footer-bottom p {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+.gano-landing-sota .footer-social {
+  display: flex;
+  gap: 16px;
+}
+.gano-landing-sota .footer-social a {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.gano-landing-sota .footer-social a:hover {
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+  transform: translateY(-2px);
+}
+
+/* ---- RESPONSIVE ---- */
+@media (max-width: 1024px) {
+  .gano-landing-sota .hero-visual {
+    display: none;
+  }
+  .gano-landing-sota .pillars-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .gano-landing-sota .pricing-grid {
+    grid-template-columns: 1fr;
+    max-width: 500px;
+    margin: 0 auto;
+  }
+  .gano-landing-sota .pricing-card.featured {
+    transform: none;
+    order: -1;
+  }
+  .gano-landing-sota .testimonials-grid {
+    grid-template-columns: 1fr;
+  }
+  .gano-landing-sota .sota-inner {
+    grid-template-columns: 1fr;
+  }
+  .gano-landing-sota .footer-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .gano-landing-sota .nav-links,
+  .gano-landing-sota .nav-cta .btn-ghost {
+    display: none;
+  }
+  .gano-landing-sota .mobile-toggle {
+    display: block;
+  }
+  .gano-landing-sota .hero {
+    padding: 120px 0 80px;
+    text-align: center;
+  }
+  .gano-landing-sota .hero-subtitle {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .gano-landing-sota .hero-ctas {
+    justify-content: center;
+  }
+  .gano-landing-sota .hero-trust {
+    justify-content: center;
+  }
+  .gano-landing-sota .pillars-grid {
+    grid-template-columns: 1fr;
+  }
+  .gano-landing-sota .sota-stats {
+    grid-template-columns: 1fr;
+  }
+  .gano-landing-sota .domain-search,
+  .gano-landing-sota .newsletter-form {
+    flex-direction: column;
+  }
+  .gano-landing-sota .service-row {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 16px;
+  }
+  .gano-landing-sota .service-icon {
+    margin: 0 auto;
+  }
+  .gano-landing-sota .service-arrow {
+    display: none;
+  }
+  .gano-landing-sota .footer-grid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .gano-landing-sota .footer-bottom {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+/* ---- SCROLL REVEAL ---- */
+.gano-landing-sota .reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.gano-landing-sota .reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/wp-content/themes/gano-child/front-page.php
+++ b/wp-content/themes/gano-child/front-page.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * Template Name: Gano Digital — Homepage
- * Description: Front page principal con hero parallax, ecosistemas dinámicos y propuesta de valor
- * SOTA aesthetic — no Elementor
+ * Description: Front page principal con landing SOTA v2. Dark aesthetic — no Elementor.
+ *
+ * @package Gano_Digital
  */
 
 get_header();
@@ -10,206 +11,551 @@ get_header();
 $url_ecosistemas = function_exists( 'gano_resolve_page_url' )
 	? gano_resolve_page_url( 'ecosistemas' )
 	: home_url( '/ecosistemas/' );
-$url_shop = function_exists( 'gano_resolve_page_url' )
-	? gano_resolve_page_url( 'shop-premium', 'tienda', 'catalogo' )
-	: home_url( '/shop-premium/' );
+
+$url_dominios = function_exists( 'gano_resolve_page_url' )
+	? gano_resolve_page_url( 'dominios' )
+	: home_url( '/dominios/' );
+
+$url_login = wp_login_url( home_url() );
 ?>
 
-<main id="gano-main-content" class="gano-home" tabindex="-1" data-gano-homepage>
-    <section class="hero-gano gano-hero-overlay">
-        <div class="hero-gano__ghost" aria-hidden="true">
-            <span class="hero-gano__ghost-line"><?php esc_html_e( 'SOTA', 'gano-child' ); ?></span>
-            <span class="hero-gano__ghost-line hero-gano__ghost-line--accent"><?php esc_html_e( 'COLOMBIA', 'gano-child' ); ?></span>
-        </div>
-        <div class="gano-shell hero-content">
-            <p class="overline"><?php esc_html_e( 'Soberanía digital · Operación Colombia', 'gano-child' ); ?></p>
-            <h1><?php esc_html_e( 'Infraestructura NVMe blindada y un agente IA que trabaja antes de que algo falle.', 'gano-child' ); ?></h1>
-            <p><?php esc_html_e( 'Hosting WordPress de alto rendimiento con seguridad de nivel empresarial, soporte en español y operación en pesos colombianos. Menos ruido, más continuidad.', 'gano-child' ); ?></p>
-            <div class="hero-cta-row">
-                <a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn-holo">
-                    <span class="label"><?php esc_html_e( 'Ver planes y arquitecturas', 'gano-child' ); ?></span>
-                    <span class="arrow">→</span>
-                </a>
-                <a href="<?php echo esc_url( $url_shop ); ?>" class="btn-gano btn-gano--secondary"><?php esc_html_e( 'Vista SOTA (demo)', 'gano-child' ); ?></a>
-            </div>
-            <ul class="hero-proof-bar" aria-label="<?php esc_attr_e( 'Señales rápidas de confianza', 'gano-child' ); ?>">
-                <li>
-                    <strong><?php esc_html_e( 'NVMe', 'gano-child' ); ?></strong>
-                    <span><?php esc_html_e( 'Stack optimizado para WordPress', 'gano-child' ); ?></span>
-                </li>
-                <li>
-                    <strong><?php esc_html_e( 'COP', 'gano-child' ); ?></strong>
-                    <span><?php esc_html_e( 'Operación comercial local', 'gano-child' ); ?></span>
-                </li>
-                <li>
-                    <strong><?php esc_html_e( '24/7', 'gano-child' ); ?></strong>
-                    <span><?php esc_html_e( 'Monitoreo y respuesta prioritaria', 'gano-child' ); ?></span>
-                </li>
-            </ul>
-            <?php
-            $url_comenzar = function_exists( 'gano_resolve_page_url' )
-                ? gano_resolve_page_url( 'comenzar-aqui', 'comenzar', 'registro-y-compra' )
-                : home_url( '/comenzar-aqui/' );
-            ?>
-            <p class="gano-home-comenzar-link">
-                <a href="<?php echo esc_url( $url_comenzar ); ?>"><?php esc_html_e( '¿Primera compra? Guía del checkout y registro →', 'gano-child' ); ?></a>
-            </p>
-        </div>
-    </section>
+<div class="gano-landing-sota">
 
-    <?php if ( function_exists( 'gano_render_content_atlas' ) ) : ?>
-    <section class="section-gano gano-home-section gano-home-section--atlas-below-hero" aria-label="<?php esc_attr_e( 'Atlas de lectura', 'gano-child' ); ?>">
-        <div class="gano-shell">
-            <?php echo gano_render_content_atlas(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-        </div>
-    </section>
-    <?php endif; ?>
+	<!-- NAVIGATION -->
+	<nav class="nav" id="navbar">
+		<div class="container nav-inner">
+			<a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="nav-logo">
+				<div class="nav-logo-icon">
+					<i class="fas fa-shield-halved"></i>
+				</div>
+				<?php echo esc_html( get_bloginfo( 'name' ) ); ?>
+			</a>
+			<ul class="nav-links">
+				<li><a href="#inicio"><?php esc_html_e( 'Inicio', 'gano-child' ); ?></a></li>
+				<li><a href="#pilares"><?php esc_html_e( 'Infraestructura', 'gano-child' ); ?></a></li>
+				<li><a href="#precios"><?php esc_html_e( 'Planes', 'gano-child' ); ?></a></li>
+				<li><a href="#servicios"><?php esc_html_e( 'Servicios', 'gano-child' ); ?></a></li>
+				<li><a href="#dominios"><?php esc_html_e( 'Dominios', 'gano-child' ); ?></a></li>
+			</ul>
+			<div class="nav-cta">
+				<a href="<?php echo esc_url( $url_login ); ?>" class="btn btn-ghost"><?php esc_html_e( 'Ingresar', 'gano-child' ); ?></a>
+				<a href="#precios" class="btn btn-primary"><?php esc_html_e( 'Crear cuenta', 'gano-child' ); ?></a>
+			</div>
+			<button class="mobile-toggle" aria-label="<?php esc_attr_e( 'Abrir menú', 'gano-child' ); ?>">
+				<i class="fas fa-bars"></i>
+			</button>
+		</div>
+	</nav>
 
-    <?php
-    // Teaser rStore de 4 tarjetas: borrador en inc/draft-home-rstore-catalog-home.php (filtro gano_show_draft_home_rstore_catalog).
-    ?>
-    <section class="section-gano gano-home-section gano-home-section--commerce-teaser" id="ecosistemas" aria-labelledby="ecosistemas-heading">
-        <div class="gano-shell gano-home-commerce-teaser">
-            <div class="section-title-gano">
-                <h2 id="ecosistemas-heading"><?php esc_html_e( 'Catálogo comercial', 'gano-child' ); ?></h2>
-                <p>
-                    <?php
-                    echo esc_html(
-                        __( 'Compara planes con precios en COP y referencia USD*, filtros por familia y checkout seguro en la página Ecosistemas.', 'gano-child' )
-                    );
-                    ?>
-                </p>
-            </div>
-            <div class="gano-home-commerce-teaser__actions">
-                <a class="btn-holo" href="<?php echo esc_url( $url_ecosistemas ); ?>">
-                    <span class="label"><?php esc_html_e( 'Abrir catálogo en Ecosistemas', 'gano-child' ); ?></span>
-                    <span class="arrow" aria-hidden="true">→</span>
-                </a>
-                <a class="btn-gano btn-gano--secondary" href="<?php echo esc_url( $url_shop ); ?>"><?php esc_html_e( 'Vista SOTA (demo)', 'gano-child' ); ?></a>
-            </div>
-        </div>
-    </section>
+	<!-- HERO -->
+	<section class="hero" id="inicio">
+		<div class="hero-bg">
+			<div class="hero-grid"></div>
+			<div class="hero-glow"></div>
+			<div class="hero-particles" id="particles"></div>
+		</div>
 
-    <section class="section-gano gano-home-section gano-home-section--surface" aria-labelledby="valor-heading">
-        <div class="gano-shell">
-            <div class="section-title-gano">
-                <h2 id="valor-heading"><?php esc_html_e( 'Cuatro pilares de la infraestructura SOTA', 'gano-child' ); ?></h2>
-                <p><?php esc_html_e( 'Lo que diferencia a Gano Digital en el mercado colombiano.', 'gano-child' ); ?></p>
-            </div>
-            <div class="value-section">
-                <div class="value-grid">
-                    <article class="value-item">
-                        <h3><?php esc_html_e( 'Velocidad real (NVMe)', 'gano-child' ); ?></h3>
-                        <p><?php esc_html_e( 'Almacenamiento de nueva generación y stack optimizado para WordPress: menos espera, más conversión. Tu sitio carga cuando el cliente ya decidió quedarse.', 'gano-child' ); ?></p>
-                    </article>
-                    <article class="value-item">
-                        <h3><?php esc_html_e( 'WordPress blindada', 'gano-child' ); ?></h3>
-                        <p><?php esc_html_e( 'Hardening continuo, controles de acceso y visibilidad sobre lo que ocurre en tu instalación. Menos superficie de ataque, más tranquilidad operativa.', 'gano-child' ); ?></p>
-                    </article>
-                    <article class="value-item">
-                        <h3><?php esc_html_e( 'Zero-Trust operativo', 'gano-child' ); ?></h3>
-                        <p><?php esc_html_e( 'Confianza cero por defecto: identidad, sesiones y permisos bajo control. La seguridad no es un cartel: es política aplicada en capas.', 'gano-child' ); ?></p>
-                    </article>
-                    <article class="value-item">
-                        <h3><?php esc_html_e( 'Edge y latencia', 'gano-child' ); ?></h3>
-                        <p><?php esc_html_e( 'Contenido más cerca del usuario sin magia barata. Arquitectura pensada para entregar experiencias rápidas donde vive tu audiencia.', 'gano-child' ); ?></p>
-                    </article>
-                </div>
-            </div>
-        </div>
-    </section>
+		<div class="container">
+			<div class="hero-content">
+				<div class="hero-badge animate-in">
+					<span class="badge badge-accent">
+						<i class="fas fa-bolt"></i>
+						<?php esc_html_e( 'SOTA — State of the Art', 'gano-child' ); ?>
+					</span>
+				</div>
 
-    <section class="section-gano gano-home-section" aria-labelledby="compromisos-heading">
-        <div class="gano-shell">
-            <div class="section-title-gano">
-                <h2 id="compromisos-heading"><?php esc_html_e( 'Compromisos operativos', 'gano-child' ); ?></h2>
-                <p><?php esc_html_e( 'Métricas de servicio enfocadas en continuidad, respuesta y acompañamiento.', 'gano-child' ); ?></p>
-            </div>
-            <div class="metrics-grid">
-                <article class="metric-box">
-                    <div class="number">99.9%</div>
-                    <div class="label"><?php esc_html_e( 'Disponibilidad esperada', 'gano-child' ); ?></div>
-                </article>
-                <article class="metric-box">
-                    <div class="number">24/7</div>
-                    <div class="label"><?php esc_html_e( 'Soporte y seguimiento', 'gano-child' ); ?></div>
-                </article>
-                <article class="metric-box">
-                    <div class="number">&lt;2h</div>
-                    <div class="label"><?php esc_html_e( 'Respuesta inicial prioritaria', 'gano-child' ); ?></div>
-                </article>
-                <article class="metric-box">
-                    <div class="number">COP</div>
-                    <div class="label"><?php esc_html_e( 'Operación comercial local', 'gano-child' ); ?></div>
-                </article>
-            </div>
-        </div>
-    </section>
+				<h1 class="hero-title animate-in delay-1">
+					<span class="line"><?php esc_html_e( 'Infraestructura NVMe', 'gano-child' ); ?></span>
+					<span class="line gradient-text"><?php esc_html_e( 'blindada', 'gano-child' ); ?></span>
+					<span class="line"><?php esc_html_e( 'y un agente IA que', 'gano-child' ); ?></span>
+					<span class="line"><?php esc_html_e( 'trabaja antes de que', 'gano-child' ); ?></span>
+					<span class="line"><?php esc_html_e( 'algo falle.', 'gano-child' ); ?></span>
+				</h1>
 
-    <?php
-    gano_cta_registro(array(
-        'heading'       => __( '¿Aún tienes dudas?', 'gano-child' ),
-        'description'   => __( 'Nuestro equipo te acompaña en cada decisión. Registra tu cuenta y accede a soporte inmediato.', 'gano-child' ),
-        'button_text'   => __( 'Crear cuenta', 'gano-child' ),
-    ));
-    ?>
+				<p class="hero-subtitle animate-in delay-2">
+					<?php esc_html_e( 'Hosting WordPress de alto rendimiento con seguridad de nivel empresarial, soporte en español y operación en pesos colombianos. Menos ruido, más continuidad.', 'gano-child' ); ?>
+				</p>
 
-    <section class="section-gano gano-home-section gano-home-section--surface" aria-labelledby="dominios-heading">
-        <div class="gano-shell">
-            <div class="section-title-gano">
-                <h2 id="dominios-heading"><?php esc_html_e( 'Encuentra tu dominio ideal', 'gano-child' ); ?></h2>
-                <p><?php esc_html_e( 'Búsqueda instantánea de TLDs disponibles para lanzar tu operación.', 'gano-child' ); ?></p>
-            </div>
-            <div class="gano-domain-search-wrap">
-                <?php echo do_shortcode( '[rstore_domain_search]' ); ?>
-            </div>
-        </div>
-    </section>
+				<div class="hero-ctas animate-in delay-3">
+					<a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn btn-primary btn-lg">
+						<i class="fas fa-rocket"></i>
+						<?php esc_html_e( 'Ver planes', 'gano-child' ); ?>
+					</a>
+					<a href="#pilares" class="btn btn-ghost btn-lg">
+						<?php esc_html_e( 'Conocer infraestructura', 'gano-child' ); ?>
+					</a>
+				</div>
 
-    <section class="section-gano gano-home-section gano-home-section--surface" aria-labelledby="lead-heading">
-        <div class="gano-shell">
-            <div class="gano-panel gano-panel--compact">
-                <h2 id="lead-heading"><?php esc_html_e( 'Primero: recibe la guía SOTA de crecimiento digital', 'gano-child' ); ?></h2>
-                <p><?php esc_html_e( 'Buenas prácticas de infraestructura, seguridad y conversión para equipos que necesitan resultados sostenibles.', 'gano-child' ); ?></p>
-                <form id="gano-lead-magnet" class="gano-lead-form" novalidate>
-                    <label for="gano-lead-email" class="screen-reader-text">Correo corporativo</label>
-                    <input
-                        id="gano-lead-email"
-                        type="email"
-                        name="email"
-                        placeholder="tu@empresa.com"
-                        autocomplete="email"
-                        required
-                    />
-                    <input type="hidden" name="nonce" value="<?php echo esc_attr( gano_lead_capture_nonce() ); ?>" />
-                    <input type="hidden" name="plan" value="homepage-sota" />
-                    <button type="submit" class="btn-gano"><?php esc_html_e( 'Recibir guía gratis', 'gano-child' ); ?></button>
-                    <p class="gano-form-status" data-gano-form-status aria-live="polite"></p>
-                </form>
-                <small><?php esc_html_e( 'Sin spam. Puedes cancelar en cualquier momento.', 'gano-child' ); ?></small>
-            </div>
-        </div>
-    </section>
+				<div class="hero-trust animate-in delay-4">
+					<div class="trust-item">
+						<i class="fas fa-microchip"></i>
+						<span>NVMe</span>
+					</div>
+					<div class="trust-item">
+						<i class="fas fa-coins"></i>
+						<span>COP</span>
+					</div>
+					<div class="trust-item">
+						<i class="fas fa-headset"></i>
+						<span>24/7</span>
+					</div>
+				</div>
+			</div>
+		</div>
 
-    <section class="section-gano gano-home-section" id="cta-final" aria-labelledby="cierre-heading">
-        <div class="gano-shell">
-            <div class="gano-panel gano-panel--compact">
-                <h2 id="cierre-heading"><?php esc_html_e( '¿Listo para una infraestructura que no te pida disculpas?', 'gano-child' ); ?></h2>
-                <?php echo do_shortcode( '[gano_cta_icons]' ); ?>
-                <p class="gano-panel-cta">
-                    <a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn-gano"><?php esc_html_e( 'Elegir mi arquitectura', 'gano-child' ); ?></a>
-                </p>
-            </div>
-        </div>
-    </section>
+		<div class="hero-visual">
+			<div class="server-rack">
+				<div class="rack-unit">
+					<div class="bar"><div class="bar-fill" style="width:78%"></div></div>
+					<span class="mono" style="font-size:0.7rem;color:var(--text-muted)">WP-01</span>
+				</div>
+				<div class="rack-unit">
+					<div class="bar"><div class="bar-fill" style="width:45%"></div></div>
+					<span class="mono" style="font-size:0.7rem;color:var(--text-muted)">WP-02</span>
+				</div>
+				<div class="rack-unit">
+					<div class="bar"><div class="bar-fill" style="width:92%"></div></div>
+					<span class="mono" style="font-size:0.7rem;color:var(--text-muted)">WP-03</span>
+				</div>
+				<div class="rack-unit">
+					<div class="bar"><div class="bar-fill" style="width:34%"></div></div>
+					<span class="mono" style="font-size:0.7rem;color:var(--text-muted)">EDGE-BOG</span>
+				</div>
+				<div class="rack-unit">
+					<div class="bar"><div class="bar-fill" style="width:61%"></div></div>
+					<span class="mono" style="font-size:0.7rem;color:var(--text-muted)">EDGE-MDE</span>
+				</div>
+			</div>
+		</div>
+	</section>
 
-    <section class="section-gano gano-home-section gano-home-section--surface" aria-label="<?php esc_attr_e( 'Confianza y respaldo', 'gano-child' ); ?>">
-        <div class="gano-shell">
-            <?php echo do_shortcode( '[gano_socio_tecnologico]' ); ?>
-            <?php echo do_shortcode( '[gano_metrics]' ); ?>
-        </div>
-    </section>
-</main>
-<?php
-get_footer();
-?>
+	<!-- SOTA BANNER -->
+	<section class="sota-banner">
+		<div class="container sota-inner">
+			<div class="sota-text reveal">
+				<span class="section-label">SOTA</span>
+				<h3><?php esc_html_e( 'State of the Art', 'gano-child' ); ?></h3>
+				<p>
+					<?php esc_html_e( 'En Gano Digital, SOTA es nuestro estándar: arquitectura y operación al nivel que el mercado considera "lo mejor disponible hoy", sin humo ni promesas genéricas. Lo aplicamos a hosting, seguridad y acompañamiento comercial para que tu equipo sepa exactamente qué compra y por qué.', 'gano-child' ); ?>
+				</p>
+			</div>
+			<div class="sota-stats">
+				<div class="sota-stat reveal">
+					<div class="sota-stat-value">99.9%</div>
+					<div class="sota-stat-label"><?php esc_html_e( 'Disponibilidad', 'gano-child' ); ?></div>
+				</div>
+				<div class="sota-stat reveal">
+					<div class="sota-stat-value">&lt;2h</div>
+					<div class="sota-stat-label"><?php esc_html_e( 'Respuesta', 'gano-child' ); ?></div>
+				</div>
+				<div class="sota-stat reveal">
+					<div class="sota-stat-value">24/7</div>
+					<div class="sota-stat-label"><?php esc_html_e( 'Monitoreo', 'gano-child' ); ?></div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- PILARS -->
+	<section class="section" id="pilares">
+		<div class="container">
+			<div class="section-header reveal">
+				<span class="section-label"><?php esc_html_e( 'Infraestructura', 'gano-child' ); ?></span>
+				<h2 class="section-title"><?php esc_html_e( 'Cuatro pilares de la', 'gano-child' ); ?> <span class="gradient-text"><?php esc_html_e( 'infraestructura SOTA', 'gano-child' ); ?></span></h2>
+				<p class="section-desc"><?php esc_html_e( 'Lo que diferencia a Gano Digital en el mercado colombiano.', 'gano-child' ); ?></p>
+			</div>
+
+			<div class="pillars-grid">
+				<div class="pillar-card reveal">
+					<div class="pillar-icon">
+						<i class="fas fa-gauge-high"></i>
+					</div>
+					<h3 class="pillar-title"><?php esc_html_e( 'Velocidad real (NVMe)', 'gano-child' ); ?></h3>
+					<p class="pillar-desc">
+						<?php esc_html_e( 'Almacenamiento de nueva generación y stack optimizado para WordPress: menos espera, más conversión. Tu sitio carga cuando el cliente ya decidió quedarse.', 'gano-child' ); ?>
+					</p>
+				</div>
+
+				<div class="pillar-card reveal">
+					<div class="pillar-icon">
+						<i class="fas fa-shield-halved"></i>
+					</div>
+					<h3 class="pillar-title"><?php esc_html_e( 'WordPress blindada', 'gano-child' ); ?></h3>
+					<p class="pillar-desc">
+						<?php esc_html_e( 'Hardening continuo, controles de acceso y visibilidad sobre lo que ocurre en tu instalación. Menos superficie de ataque, más tranquilidad operativa.', 'gano-child' ); ?>
+					</p>
+				</div>
+
+				<div class="pillar-card reveal">
+					<div class="pillar-icon">
+						<i class="fas fa-fingerprint"></i>
+					</div>
+					<h3 class="pillar-title"><?php esc_html_e( 'Zero-Trust operativo', 'gano-child' ); ?></h3>
+					<p class="pillar-desc">
+						<?php esc_html_e( 'Confianza cero por defecto: identidad, sesiones y permisos bajo control. La seguridad no es un cartel: es política aplicada en capas.', 'gano-child' ); ?>
+					</p>
+				</div>
+
+				<div class="pillar-card reveal">
+					<div class="pillar-icon">
+						<i class="fas fa-globe"></i>
+					</div>
+					<h3 class="pillar-title"><?php esc_html_e( 'Edge y latencia', 'gano-child' ); ?></h3>
+					<p class="pillar-desc">
+						<?php esc_html_e( 'Contenido más cerca del usuario sin magia barata. Arquitectura pensada para entregar experiencias rápidas donde vive tu audiencia.', 'gano-child' ); ?>
+					</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- PRICING -->
+	<section class="section" id="precios" style="background: var(--bg-surface);">
+		<div class="container">
+			<div class="section-header reveal">
+				<span class="section-label"><?php esc_html_e( 'Catálogo comercial', 'gano-child' ); ?></span>
+				<h2 class="section-title"><?php esc_html_e( 'Planes con precios en', 'gano-child' ); ?> <span class="gradient-text">COP</span></h2>
+				<p class="section-desc"><?php esc_html_e( 'Compara planes con referencia USD* y elige el que necesita tu operación.', 'gano-child' ); ?></p>
+			</div>
+
+			<div class="pricing-tabs reveal">
+				<button class="pricing-tab active"><?php esc_html_e( 'WordPress', 'gano-child' ); ?></button>
+				<button class="pricing-tab"><?php esc_html_e( 'Compartido', 'gano-child' ); ?></button>
+				<button class="pricing-tab"><?php esc_html_e( 'VPS', 'gano-child' ); ?></button>
+			</div>
+
+			<div class="pricing-grid" id="pricing-wordpress">
+				<div class="pricing-card reveal">
+					<div class="pricing-name"><?php esc_html_e( 'Esencial', 'gano-child' ); ?></div>
+					<div class="pricing-desc"><?php esc_html_e( 'Para emprendedores y proyectos nuevos', 'gano-child' ); ?></div>
+					<div class="pricing-price">
+						<span class="currency">$</span>
+						<span class="amount">29.900</span>
+						<span class="period">/mes</span>
+						<div class="usd">~$7.50 USD</div>
+					</div>
+					<ul class="pricing-features">
+						<li><i class="fas fa-check"></i> <?php esc_html_e( '1 sitio web', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( '10 GB NVMe', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( '100 GB ancho de banda', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'SSL gratuito', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'cPanel incluido', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Soporte 24/7', 'gano-child' ); ?></li>
+						<li class="muted"><i class="fas fa-xmark"></i> <?php esc_html_e( 'CDN Edge', 'gano-child' ); ?></li>
+						<li class="muted"><i class="fas fa-xmark"></i> <?php esc_html_e( 'Backups diarios', 'gano-child' ); ?></li>
+					</ul>
+					<a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn btn-ghost" style="width:100%"><?php esc_html_e( 'Elegir plan', 'gano-child' ); ?></a>
+				</div>
+
+				<div class="pricing-card featured reveal">
+					<div class="pricing-badge"><?php esc_html_e( 'Más popular', 'gano-child' ); ?></div>
+					<div class="pricing-name"><?php esc_html_e( 'Profesional', 'gano-child' ); ?></div>
+					<div class="pricing-desc"><?php esc_html_e( 'Para negocios en crecimiento', 'gano-child' ); ?></div>
+					<div class="pricing-price">
+						<span class="currency">$</span>
+						<span class="amount">79.900</span>
+						<span class="period">/mes</span>
+						<div class="usd">~$19.90 USD</div>
+					</div>
+					<ul class="pricing-features">
+						<li><i class="fas fa-check"></i> <?php esc_html_e( '5 sitios web', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( '50 GB NVMe', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Ancho de banda ilimitado', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'SSL gratuito', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'cPanel + Softaculous', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'CDN Edge Colombia', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Backups diarios', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Migración gratuita', 'gano-child' ); ?></li>
+					</ul>
+					<a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn btn-primary" style="width:100%"><?php esc_html_e( 'Elegir plan', 'gano-child' ); ?></a>
+				</div>
+
+				<div class="pricing-card reveal">
+					<div class="pricing-name"><?php esc_html_e( 'Empresarial', 'gano-child' ); ?></div>
+					<div class="pricing-desc"><?php esc_html_e( 'Para operaciones de alto tráfico', 'gano-child' ); ?></div>
+					<div class="pricing-price">
+						<span class="currency">$</span>
+						<span class="amount">149.900</span>
+						<span class="period">/mes</span>
+						<div class="usd">~$37.50 USD</div>
+					</div>
+					<ul class="pricing-features">
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Sitios ilimitados', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( '100 GB NVMe', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Ancho de banda ilimitado', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'SSL Wildcard', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'cPanel + WHM', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'CDN Global + Edge', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'Backups en tiempo real', 'gano-child' ); ?></li>
+						<li><i class="fas fa-check"></i> <?php esc_html_e( 'IP dedicada', 'gano-child' ); ?></li>
+					</ul>
+					<a href="<?php echo esc_url( $url_ecosistemas ); ?>" class="btn btn-ghost" style="width:100%"><?php esc_html_e( 'Elegir plan', 'gano-child' ); ?></a>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- SERVICES -->
+	<section class="section" id="servicios">
+		<div class="container">
+			<div class="section-header reveal">
+				<span class="section-label"><?php esc_html_e( 'Servicios', 'gano-child' ); ?></span>
+				<h2 class="section-title"><?php esc_html_e( 'Blindaje y', 'gano-child' ); ?> <span class="gradient-text"><?php esc_html_e( 'Optimización', 'gano-child' ); ?></span></h2>
+				<p class="section-desc"><?php esc_html_e( 'Capas de seguridad avanzada e inteligencia aplicadas a tu presencia digital.', 'gano-child' ); ?></p>
+			</div>
+
+			<div class="services-list">
+				<div class="service-row reveal">
+					<div class="service-icon">
+						<i class="fas fa-shield-virus"></i>
+					</div>
+					<div class="service-info">
+						<h4><?php esc_html_e( 'Inmunidad Digital (SSL + WAF)', 'gano-child' ); ?></h4>
+						<p><?php esc_html_e( 'Encriptación de grado militar y firewalls de aplicación web que aprenden y neutralizan amenazas antes de que toquen tu servidor.', 'gano-child' ); ?></p>
+					</div>
+					<div class="service-arrow">
+						<i class="fas fa-arrow-right"></i>
+					</div>
+				</div>
+
+				<div class="service-row reveal">
+					<div class="service-icon">
+						<i class="fas fa-magnifying-glass-chart"></i>
+					</div>
+					<div class="service-info">
+						<h4><?php esc_html_e( 'SEO de Autoridad Monolítica', 'gano-child' ); ?></h4>
+						<p><?php esc_html_e( 'Estrategias de posicionamiento diseñadas para dominar las búsquedas más competitivas en el mercado colombiano.', 'gano-child' ); ?></p>
+					</div>
+					<div class="service-arrow">
+						<i class="fas fa-arrow-right"></i>
+					</div>
+				</div>
+
+				<div class="service-row reveal">
+					<div class="service-icon">
+						<i class="fas fa-bolt"></i>
+					</div>
+					<div class="service-info">
+						<h4><?php esc_html_e( 'Aceleración Anycast', 'gano-child' ); ?></h4>
+						<p><?php esc_html_e( 'Distribución de contenido en el borde (Edge Computing). Tu sitio se sirve desde el nodo más cercano a tu cliente.', 'gano-child' ); ?></p>
+					</div>
+					<div class="service-arrow">
+						<i class="fas fa-arrow-right"></i>
+					</div>
+				</div>
+
+				<div class="service-row reveal">
+					<div class="service-icon">
+						<i class="fas fa-database"></i>
+					</div>
+					<div class="service-info">
+						<h4><?php esc_html_e( 'Resiliencia y Backup SOTA', 'gano-child' ); ?></h4>
+						<p><?php esc_html_e( 'Snapshotting continuo y backups granulares. En caso de desastre, tu infraestructura se reconstruye en segundos.', 'gano-child' ); ?></p>
+					</div>
+					<div class="service-arrow">
+						<i class="fas fa-arrow-right"></i>
+					</div>
+				</div>
+
+				<div class="service-row reveal">
+					<div class="service-icon">
+						<i class="fas fa-envelope-circle-check"></i>
+					</div>
+					<div class="service-info">
+						<h4><?php esc_html_e( 'Elitismo en Conectividad', 'gano-child' ); ?></h4>
+						<p><?php esc_html_e( 'Correo profesional y herramientas de colaboración (GWS / M365) configuradas bajo estándares de seguridad Gano.', 'gano-child' ); ?></p>
+					</div>
+					<div class="service-arrow">
+						<i class="fas fa-arrow-right"></i>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- DOMAIN SEARCH -->
+	<section class="section domain-section" id="dominios">
+		<div class="container">
+			<div class="domain-box reveal">
+				<span class="section-label"><?php esc_html_e( 'Dominios', 'gano-child' ); ?></span>
+				<h2 class="section-title" style="margin-bottom: 8px;"><?php esc_html_e( 'Encuentra tu dominio ideal', 'gano-child' ); ?></h2>
+				<p class="section-desc" style="margin-bottom: 0;"><?php esc_html_e( 'Búsqueda instantánea de TLDs disponibles para lanzar tu operación.', 'gano-child' ); ?></p>
+
+				<form class="domain-search" action="<?php echo esc_url( $url_dominios ); ?>" method="get">
+					<input type="text" name="domain" class="domain-input" placeholder="tunegocio" aria-label="<?php esc_attr_e( 'Nombre de dominio', 'gano-child' ); ?>">
+					<button type="submit" class="btn btn-primary btn-lg">
+						<i class="fas fa-search"></i>
+						<?php esc_html_e( 'Buscar', 'gano-child' ); ?>
+					</button>
+				</form>
+
+				<div class="domain-tlds">
+					<div class="tld-tag">.com <span class="price">$45.000</span></div>
+					<div class="tld-tag">.co <span class="price">$55.000</span></div>
+					<div class="tld-tag">.com.co <span class="price">$35.000</span></div>
+					<div class="tld-tag">.net <span class="price">$48.000</span></div>
+					<div class="tld-tag">.org <span class="price">$50.000</span></div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- TESTIMONIALS -->
+	<section class="section">
+		<div class="container">
+			<div class="section-header reveal">
+				<span class="section-label"><?php esc_html_e( 'Confianza', 'gano-child' ); ?></span>
+				<h2 class="section-title"><?php esc_html_e( 'Lo que dicen nuestros', 'gano-child' ); ?> <span class="gradient-text"><?php esc_html_e( 'clientes', 'gano-child' ); ?></span></h2>
+				<p class="section-desc"><?php esc_html_e( 'Empresas colombianas que ya operan con infraestructura SOTA.', 'gano-child' ); ?></p>
+			</div>
+
+			<div class="testimonials-grid">
+				<div class="testimonial-card reveal">
+					<div class="stars">
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+					</div>
+					<p class="testimonial-text">
+						"<?php esc_html_e( 'Migrar a Gano Digital redujo nuestro tiempo de carga en un 60%. El soporte técnico local entiende nuestro negocio y responde en minutos, no en horas.', 'gano-child' ); ?>"
+					</p>
+					<div class="testimonial-author">
+						<div class="testimonial-avatar">CM</div>
+						<div>
+							<div class="testimonial-name">Carlos Méndez</div>
+							<div class="testimonial-role"><?php esc_html_e( 'CTO — TiendaVirtual.co', 'gano-child' ); ?></div>
+						</div>
+					</div>
+				</div>
+
+				<div class="testimonial-card reveal">
+					<div class="stars">
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+					</div>
+					<p class="testimonial-text">
+						"<?php esc_html_e( 'La facturación en COP y el soporte en español fueron decisivos. Pero lo que realmente nos sorprendió fue la velocidad: NVMe se siente.', 'gano-child' ); ?>"
+					</p>
+					<div class="testimonial-author">
+						<div class="testimonial-avatar">AR</div>
+						<div>
+							<div class="testimonial-name">Ana Rodríguez</div>
+							<div class="testimonial-role"><?php esc_html_e( 'Directora — Agencia Bloom', 'gano-child' ); ?></div>
+						</div>
+					</div>
+				</div>
+
+				<div class="testimonial-card reveal">
+					<div class="stars">
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star"></i>
+						<i class="fas fa-star-half-stroke"></i>
+					</div>
+					<p class="testimonial-text">
+						"<?php esc_html_e( 'Después de un intento de ataque, el WAF de Gano bloqueó todo antes de que impactara. Zero-Trust no es marketing: es política real aplicada a nuestra infraestructura.', 'gano-child' ); ?>"
+					</p>
+					<div class="testimonial-author">
+						<div class="testimonial-avatar">JP</div>
+						<div>
+							<div class="testimonial-name">Juan Pablo L.</div>
+							<div class="testimonial-role"><?php esc_html_e( 'Fundador — Fintech Andina', 'gano-child' ); ?></div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- NEWSLETTER -->
+	<section class="section">
+		<div class="container">
+			<div class="newsletter-box reveal">
+				<span class="section-label"><?php esc_html_e( 'Recursos', 'gano-child' ); ?></span>
+				<h2 class="section-title" style="margin-bottom: 12px;"><?php esc_html_e( 'Primero: recibe la guía SOTA', 'gano-child' ); ?></h2>
+				<p class="section-desc" style="max-width: 560px; margin: 0 auto;">
+					<?php esc_html_e( 'Buenas prácticas de infraestructura, seguridad y conversión para equipos que necesitan resultados sostenibles. Sin spam. Cancela cuando quieras.', 'gano-child' ); ?>
+				</p>
+				<form class="newsletter-form" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post" id="gano-landing-newsletter">
+					<?php wp_nonce_field( 'gano_pre_registro_nonce', 'nonce' ); ?>
+					<input type="hidden" name="action" value="gano_pre_registro">
+					<input type="email" name="gano_email" class="newsletter-input" placeholder="tu@empresa.com" required aria-label="<?php esc_attr_e( 'Correo electrónico', 'gano-child' ); ?>">
+					<button type="submit" class="btn btn-primary">
+						<i class="fas fa-paper-plane"></i>
+						<?php esc_html_e( 'Suscribirse', 'gano-child' ); ?>
+					</button>
+				</form>
+			</div>
+		</div>
+	</section>
+
+	<!-- FOOTER -->
+	<footer class="footer">
+		<div class="container">
+			<div class="footer-grid">
+				<div class="footer-brand">
+					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="logo">
+						<div class="nav-logo-icon" style="width:32px;height:32px;font-size:0.875rem;">
+							<i class="fas fa-shield-halved"></i>
+						</div>
+						<?php echo esc_html( get_bloginfo( 'name' ) ); ?>
+					</a>
+					<p>
+						<?php esc_html_e( 'Un socio tecnológico que trabaja en silencio. Infraestructura seria, soporte en tu idioma y visibilidad sobre lo que pasa detrás del sitio.', 'gano-child' ); ?>
+					</p>
+				</div>
+
+				<div class="footer-col">
+					<h4><?php esc_html_e( 'Productos', 'gano-child' ); ?></h4>
+					<ul>
+						<li><a href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Hosting WordPress', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Hosting Compartido', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'VPS Cloud', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Servidores Dedicados', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( $url_ecosistemas ); ?>"><?php esc_html_e( 'Creador de Sitios', 'gano-child' ); ?></a></li>
+					</ul>
+				</div>
+
+				<div class="footer-col">
+					<h4><?php esc_html_e( 'Empresa', 'gano-child' ); ?></h4>
+					<ul>
+						<li><a href="<?php echo esc_url( home_url( '/nosotros/' ) ); ?>"><?php esc_html_e( 'Sobre nosotros', 'gano-child' ); ?></a></li>
+						<li><a href="#"><?php esc_html_e( 'Estado de red', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( home_url( '/blog/' ) ); ?>"><?php esc_html_e( 'Blog', 'gano-child' ); ?></a></li>
+						<li><a href="#"><?php esc_html_e( 'Preguntas frecuentes', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( home_url( '/contacto/' ) ); ?>"><?php esc_html_e( 'Contacto', 'gano-child' ); ?></a></li>
+					</ul>
+				</div>
+
+				<div class="footer-col">
+					<h4><?php esc_html_e( 'Legal', 'gano-child' ); ?></h4>
+					<ul>
+						<li><a href="<?php echo esc_url( home_url( '/terminos/' ) ); ?>"><?php esc_html_e( 'Términos y condiciones', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( home_url( '/privacidad/' ) ); ?>"><?php esc_html_e( 'Política de privacidad', 'gano-child' ); ?></a></li>
+						<li><a href="#"><?php esc_html_e( 'Política de uso', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( home_url( '/sla/' ) ); ?>"><?php esc_html_e( 'SLA', 'gano-child' ); ?></a></li>
+					</ul>
+				</div>
+			</div>
+
+			<div class="footer-bottom">
+				<p>© <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php echo esc_html( get_bloginfo( 'name' ) ); ?>. <?php esc_html_e( 'Soberanía digital · Operación Colombia.', 'gano-child' ); ?></p>
+				<div class="footer-social">
+					<a href="#" aria-label="X / Twitter"><i class="fab fa-x-twitter"></i></a>
+					<a href="#" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+					<a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+					<a href="#" aria-label="GitHub"><i class="fab fa-github"></i></a>
+				</div>
+			</div>
+		</div>
+	</footer>
+
+</div><!-- /.gano-landing-sota -->
+
+<?php get_footer(); ?>

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -384,29 +384,32 @@ function gano_child_enqueue_styles() {
     wp_enqueue_style( 'gano-child-style', get_stylesheet_uri(), array( 'royal-elementor-kit-parent' ), wp_get_theme()->get( 'Version' ) );
 
     // Homepage SOTA — solo en front page
+    /* -------------------------------------------------------------------------
+       Landing SOTA v2 — reemplazo completo de front-page.php
+       ---------------------------------------------------------------------- */
     if ( is_front_page() ) {
-        $homepage_css_path = get_stylesheet_directory() . '/css/homepage.css';
-        $homepage_css_ver  = file_exists( $homepage_css_path ) ? (string) filemtime( $homepage_css_path ) : wp_get_theme()->get( 'Version' );
-        wp_enqueue_style( 'gano-homepage-css', get_stylesheet_directory_uri() . '/css/homepage.css', array( 'gano-child-style' ), $homepage_css_ver );
+        // CSS landing SOTA v2
+        $landing_css_path = get_stylesheet_directory() . '/css/landing-sota-v2.css';
+        $landing_css_ver  = file_exists( $landing_css_path ) ? (string) filemtime( $landing_css_path ) : wp_get_theme()->get( 'Version' );
+        wp_enqueue_style( 'gano-landing-sota-v2', get_stylesheet_directory_uri() . '/css/landing-sota-v2.css', array( 'gano-child-style' ), $landing_css_ver );
 
-        $homepage_js_path = get_stylesheet_directory() . '/js/gano-homepage.js';
-        $homepage_js_ver  = file_exists( $homepage_js_path ) ? (string) filemtime( $homepage_js_path ) : wp_get_theme()->get( 'Version' );
+        // JS landing SOTA v2
+        $landing_js_path = get_stylesheet_directory() . '/js/landing-sota-v2.js';
+        $landing_js_ver  = file_exists( $landing_js_path ) ? (string) filemtime( $landing_js_path ) : wp_get_theme()->get( 'Version' );
         wp_enqueue_script(
-            'gano-homepage-js',
-            get_stylesheet_directory_uri() . '/js/gano-homepage.js',
+            'gano-landing-sota-v2-js',
+            get_stylesheet_directory_uri() . '/js/landing-sota-v2.js',
             array(),
-            $homepage_js_ver,
+            $landing_js_ver,
             true
         );
-        wp_localize_script(
-            'gano-homepage-js',
-            'ganoHomepageConfig',
-            array(
-                'leadEndpoint' => rest_url( 'gano/v1/lead-capture' ),
-            )
-        );
-        if ( function_exists( 'gano_content_atlas_enqueue_assets' ) ) {
-            gano_content_atlas_enqueue_assets();
+
+        // Ocultar header del tema padre (royal-elementor-kit) en landing
+        wp_add_inline_style( 'gano-child-style', '#site-header { display: none !important; }' );
+
+        // Font Awesome 6.5.1 si no está cargado por otro plugin/tema
+        if ( ! wp_script_is( 'font-awesome', 'enqueued' ) && ! wp_script_is( 'fontawesome', 'enqueued' ) ) {
+            wp_enqueue_style( 'font-awesome-6', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css', array(), '6.5.1' );
         }
     }
 

--- a/wp-content/themes/gano-child/js/landing-sota-v2.js
+++ b/wp-content/themes/gano-child/js/landing-sota-v2.js
@@ -1,0 +1,116 @@
+/**
+ * Gano Digital — Landing SOTA V2
+ * Scoped to .gano-landing-sota. Encapsulated to avoid global namespace pollution.
+ */
+(function () {
+  'use strict';
+
+  const landing = document.querySelector('.gano-landing-sota');
+  if (!landing) return;
+
+  /* ---- Navbar scroll effect ---- */
+  const navbar = landing.querySelector('#navbar');
+  if (navbar) {
+    window.addEventListener('scroll', function () {
+      if (window.scrollY > 50) {
+        navbar.classList.add('scrolled');
+      } else {
+        navbar.classList.remove('scrolled');
+      }
+    });
+  }
+
+  /* ---- Generate particles ---- */
+  const particlesContainer = landing.querySelector('#particles');
+  if (particlesContainer) {
+    for (let i = 0; i < 30; i++) {
+      const p = document.createElement('div');
+      p.className = 'particle';
+      p.style.left = Math.random() * 100 + '%';
+      p.style.top = Math.random() * 100 + '%';
+      p.style.animationDelay = Math.random() * 6 + 's';
+      p.style.animationDuration = (4 + Math.random() * 4) + 's';
+      particlesContainer.appendChild(p);
+    }
+  }
+
+  /* ---- Scroll reveal ---- */
+  const revealElements = landing.querySelectorAll('.reveal');
+  if (revealElements.length && 'IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+        }
+      });
+    }, {
+      threshold: 0.1,
+      rootMargin: '0px 0px -50px 0px'
+    });
+    revealElements.forEach(function (el) { observer.observe(el); });
+  } else {
+    revealElements.forEach(function (el) { el.classList.add('visible'); });
+  }
+
+  /* ---- Pricing tabs (delegation) ---- */
+  landing.addEventListener('click', function (e) {
+    const tab = e.target.closest('.pricing-tab');
+    if (!tab) return;
+    e.preventDefault();
+    landing.querySelectorAll('.pricing-tab').forEach(function (t) {
+      t.classList.remove('active');
+    });
+    tab.classList.add('active');
+  });
+
+  /* ---- Mobile menu toggle ---- */
+  landing.addEventListener('click', function (e) {
+    const toggle = e.target.closest('.mobile-toggle');
+    if (!toggle) return;
+    e.preventDefault();
+    const navLinks = landing.querySelector('.nav-links');
+    const navCta = landing.querySelector('.nav-cta');
+    if (navLinks && navCta) {
+      const isHidden = navLinks.style.display === 'none' || getComputedStyle(navLinks).display === 'none';
+      if (isHidden) {
+        navLinks.style.display = 'flex';
+        navCta.style.display = 'flex';
+        navLinks.style.flexDirection = 'column';
+        navLinks.style.position = 'absolute';
+        navLinks.style.top = '100%';
+        navLinks.style.left = '0';
+        navLinks.style.right = '0';
+        navLinks.style.background = 'rgba(5,5,8,0.95)';
+        navLinks.style.padding = '24px';
+        navLinks.style.backdropFilter = 'blur(20px)';
+        navLinks.style.borderBottom = '1px solid var(--border-subtle)';
+      } else {
+        navLinks.style.display = '';
+        navCta.style.display = '';
+        navLinks.style.flexDirection = '';
+        navLinks.style.position = '';
+        navLinks.style.top = '';
+        navLinks.style.left = '';
+        navLinks.style.right = '';
+        navLinks.style.background = '';
+        navLinks.style.padding = '';
+        navLinks.style.backdropFilter = '';
+        navLinks.style.borderBottom = '';
+      }
+    }
+  });
+
+  /* ---- Smooth scroll for anchor links ---- */
+  landing.addEventListener('click', function (e) {
+    const anchor = e.target.closest('a[href^="#"]');
+    if (!anchor) return;
+    const targetId = anchor.getAttribute('href');
+    if (!targetId || targetId === '#') return;
+    const target = document.querySelector(targetId);
+    if (target) {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+
+})();


### PR DESCRIPTION
## Cambios
- Reemplaza front-page.php con landing SOTA v2 dark completa
- CSS scoped en css/landing-sota-v2.css (namespace .gano-landing-sota)
- JS encapsulado en js/landing-sota-v2.js (vanilla ES6+, sin jQuery)
- Oculta #site-header del tema padre en front page
- CTAs conectados a catálogo Reseller (/ecosistemas/) y dominios (/dominios/)
- Newsletter conectada al handler AJAX gano_pre_registro existente
- Font Awesome 6.5.1 cargado condicionalmente

## Verificación
- [x] php -l OK en front-page.php y functions.php
- [x] CSS scoped, sin colisiones con design system existente
- [x] No secrets commiteados