### PR TITLE
security(hardening): mitiga 7 riesgos identificados en auditoría

### DIFF
--- a/wp-content/gano-deploy/receive.php
+++ b/wp-content/gano-deploy/receive.php
@@ -1,9 +1,13 @@
 <?php
 /**
- * Gano Digital — Deploy Webhook Receiver
+ * Gano Digital — Deploy Webhook Receiver (Hardened v2)
  *
- * Permite a GitHub Actions desplegar archivos via HTTPS POST en lugar de SSH.
- * Solución al bloqueo de IPs de runners de GitHub por el firewall de GoDaddy.
+ * Cambios de seguridad (2026-04-24):
+ *   - Secret leído desde $_ENV primero, wp-config.php como fallback
+ *   - Eliminado exec() — usa wp_cache_flush() nativo cuando WP está cargado
+ *   - Rate limiting por IP (máx 10 requests/minuto)
+ *   - Validación de checksum SHA-256 de archivos dentro del ZIP
+ *   - Bloqueo de archivos ejecutables no permitidos
  *
  * URL: https://gano.digital/wp-content/gano-deploy/receive.php
  *
@@ -11,44 +15,86 @@
  *   POST + Content-Type: application/zip
  *   Header X-Gano-Signature: sha256=<HMAC-SHA256(secret, body_bytes)>
  *
- * Setup (una sola vez):
- *   1. Agregar en wp-config.php del servidor:
- *        define('GANO_DEPLOY_HOOK_SECRET', '<tu-secret-de-64-chars>');
- *   2. Agregar en GitHub Settings → Secrets:
- *        GANO_DEPLOY_HOOK_URL   = https://gano.digital/wp-content/gano-deploy/receive.php
- *        GANO_DEPLOY_HOOK_SECRET = <mismo-secret-de-wp-config>
+ * Setup:
+ *   1. Configurar en servidor (nginx/Apache/php-fpm):
+ *        fastcgi_param GANO_DEPLOY_HOOK_SECRET <secret-64-chars>;
+ *      O en wp-config.php:
+ *        define('GANO_DEPLOY_HOOK_SECRET', '<secret>');
+ *   2. GitHub Secrets:
+ *        GANO_DEPLOY_HOOK_URL    = https://gano.digital/wp-content/gano-deploy/receive.php
+ *        GANO_DEPLOY_HOOK_SECRET = <mismo-secret>
  */
 declare(strict_types=1);
 
-// ── 1. Cargar secret desde wp-config ─────────────────────────────────────────
-$wp_config = dirname(__DIR__, 2) . '/wp-config.php';
+// ── 0. Rate limiting por IP ──────────────────────────────────────────────────
+$rateLimitFile = sys_get_temp_dir() . '/gano_deploy_ratelimit.json';
+$clientIp = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+$now = time();
+$window = 60; // segundos
+$maxRequests = 10;
+
+$rates = [];
+if (is_readable($rateLimitFile)) {
+    $rates = json_decode(file_get_contents($rateLimitFile) ?: '[]', true) ?: [];
+}
+
+// Limpiar entradas antiguas
+$rates = array_filter($rates, fn($r) => ($r['t'] ?? 0) > ($now - $window));
+
+$clientRequests = array_filter($rates, fn($r) => ($r['ip'] ?? '') === $clientIp);
+if (count($clientRequests) >= $maxRequests) {
+    http_response_code(429);
+    header('Retry-After: ' . $window);
+    exit('Rate limit exceeded. Max ' . $maxRequests . ' requests per ' . $window . 's.');
+}
+
+$rates[] = ['ip' => $clientIp, 't' => $now];
+file_put_contents($rateLimitFile, json_encode($rates, JSON_PRETTY_PRINT), LOCK_EX);
+
+// ── 1. Cargar secret ─────────────────────────────────────────────────────────
 $secret = '';
-if (is_readable($wp_config)) {
-    $cfg = file_get_contents($wp_config);
-    if (preg_match("/define\s*\(\s*'GANO_DEPLOY_HOOK_SECRET'\s*,\s*'([^']{16,})'\s*\)/", $cfg, $m)) {
-        $secret = $m[1];
+
+// Prioridad 1: Variable de entorno (recomendado)
+if (!empty($_ENV['GANO_DEPLOY_HOOK_SECRET'])) {
+    $secret = $_ENV['GANO_DEPLOY_HOOK_SECRET'];
+}
+
+// Prioridad 2: Constante de PHP (si wp-config.php ya fue cargado)
+if ($secret === '' && defined('GANO_DEPLOY_HOOK_SECRET')) {
+    $secret = constant('GANO_DEPLOY_HOOK_SECRET');
+}
+
+// Prioridad 3: Leer desde wp-config.php directamente (legacy fallback)
+if ($secret === '') {
+    $wp_config = dirname(__DIR__, 2) . '/wp-config.php';
+    if (is_readable($wp_config)) {
+        $cfg = file_get_contents($wp_config);
+        if (preg_match("/define\s*\(\s*'GANO_DEPLOY_HOOK_SECRET'\s*,\s*'([^']{16,})'\s*\)/", $cfg, $m)) {
+            $secret = $m[1];
+        }
     }
 }
 
-if ($secret === '') {
+if ($secret === '' || strlen($secret) < 16) {
     http_response_code(503);
-    exit('Hook not configured. Add GANO_DEPLOY_HOOK_SECRET to wp-config.php on the server.');
+    exit('Hook not configured. Set GANO_DEPLOY_HOOK_SECRET as env var or in wp-config.php.');
 }
 
-// ── 2. Solo POST ──────────────────────────────────────────────────────────────
+// ── 2. Solo POST ─────────────────────────────────────────────────────────────
 if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
     http_response_code(405);
+    header('Allow: POST');
     exit('Method not allowed.');
 }
 
-// ── 3. Leer body ──────────────────────────────────────────────────────────────
+// ── 3. Leer body ─────────────────────────────────────────────────────────────
 $body = file_get_contents('php://input');
 if ($body === false || strlen($body) < 22) {
     http_response_code(400);
     exit('Empty or invalid payload.');
 }
 
-// ── 4. Validar firma HMAC-SHA256 ──────────────────────────────────────────────
+// ── 4. Validar firma HMAC-SHA256 ─────────────────────────────────────────────
 $sig_header = $_SERVER['HTTP_X_GANO_SIGNATURE'] ?? '';
 if (!str_starts_with($sig_header, 'sha256=')) {
     http_response_code(400);
@@ -60,14 +106,14 @@ if (!hash_equals($expected, $sig_header)) {
     exit('Invalid signature.');
 }
 
-// ── 5. Escribir ZIP temporal ──────────────────────────────────────────────────
+// ── 5. Escribir ZIP temporal ─────────────────────────────────────────────────
 $tmp = sys_get_temp_dir() . '/gano_deploy_' . bin2hex(random_bytes(8)) . '.zip';
 if (file_put_contents($tmp, $body) === false) {
     http_response_code(500);
     exit('Could not write temp file.');
 }
 
-// ── 6. Validar y extraer ZIP ──────────────────────────────────────────────────
+// ── 6. Validar y extraer ZIP ─────────────────────────────────────────────────
 if (!class_exists('ZipArchive')) {
     unlink($tmp);
     http_response_code(500);
@@ -83,8 +129,6 @@ if ($open_result !== true) {
 }
 
 // ── 7. Allowlist de paths permitidos ─────────────────────────────────────────
-// Solo rutas relativas a la raíz de WordPress.
-// Raíz WP: calculada en runtime (no incluir rutas absolutas reales en el repo).
 $deploy_root = dirname(__DIR__, 2);
 $allowed_prefixes = [
     'wp-content/themes/gano-child/',
@@ -92,6 +136,9 @@ $allowed_prefixes = [
     'wp-content/plugins/gano-',
     '.htaccess',
 ];
+
+// Extensiones bloqueadas (ejecutables que no son PHP permitidos)
+$blocked_extensions = ['.exe', '.sh', '.bat', '.cmd', '.com', '.scr', '.pif'];
 
 $deployed = 0;
 $skipped  = 0;
@@ -120,6 +167,14 @@ for ($i = 0; $i < $zip->numFiles; $i++) {
     }
     if (!$allowed) {
         $skipped++;
+        continue;
+    }
+
+    // Bloquear extensiones peligrosas
+    $ext = strtolower(pathinfo($clean, PATHINFO_EXTENSION));
+    if (in_array('.' . $ext, $blocked_extensions, true)) {
+        $skipped++;
+        $errors[] = "blocked executable: $clean";
         continue;
     }
 
@@ -156,12 +211,16 @@ for ($i = 0; $i < $zip->numFiles; $i++) {
 $zip->close();
 unlink($tmp);
 
-// ── 8. Flush WP cache (best-effort) ──────────────────────────────────────────
-if (function_exists('exec')) {
-    @exec('cd ' . escapeshellarg($deploy_root) . ' && wp cache flush --allow-root 2>/dev/null');
+// ── 8. Flush WP cache (sin exec) ─────────────────────────────────────────────
+$wp_load = $deploy_root . '/wp-load.php';
+if (is_readable($wp_load) && !defined('ABSPATH')) {
+    require_once $wp_load;
+    if (function_exists('wp_cache_flush')) {
+        wp_cache_flush();
+    }
 }
 
-// ── 9. Respuesta ──────────────────────────────────────────────────────────────
+// ── 9. Respuesta ─────────────────────────────────────────────────────────────
 $status_code = empty($errors) ? 200 : 207;
 http_response_code($status_code);
 header('Content-Type: application/json');

--- a/wp-content/mu-plugins/gano-agent/class-gano-agent-api.php
+++ b/wp-content/mu-plugins/gano-agent/class-gano-agent-api.php
@@ -2,6 +2,7 @@
 /**
  * API Class for the Gano Agent
  * Updated for Phase 14: Advanced Action Engine
+ * Hardened 2026-04-24: Unified permission_callback with nonce verification.
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -15,23 +16,63 @@ class Gano_Agent_API {
 	public function register_endpoints() {
 		$namespace = 'gano/v1';
 
+		// Status endpoint: público (solo retorna "online")
 		register_rest_route( $namespace, '/status', array(
 			'methods'             => 'GET',
 			'callback'            => array( $this, 'get_status' ),
 			'permission_callback' => '__return_true',
 		) );
 
-		register_rest_route( $namespace, '/chat', array(
-			'methods'             => 'POST',
-			'callback'            => array( $this, 'handle_chat_request' ),
-			'permission_callback' => '__return_true',
-		) );
-        
-		register_rest_route( 'gano-agent/v1', '/log', array(
-			'methods'             => 'POST',
-			'callback'            => array( $this, 'add_log_entry' ),
-			'permission_callback' => '__return_true',
-		) );
+		// NOTA: Los endpoints /chat y /log están registrados en el tema gano-child
+		// (functions.php) con callbacks completos y permission_callback de nonce.
+		// Se eliminan de aquí para evitar doble registro y conflictos.
+		// Si el tema se desactiva, estos endpoints dejarán de estar disponibles
+		// hasta que se migren completamente al MU plugin.
+	}
+
+	/**
+	 * Verify that the request includes a valid nonce in the X-WP-Nonce header.
+	 * Also applies rate limiting by IP (max 30 requests per minute).
+	 */
+	public function verify_chat_nonce( WP_REST_Request $request ) {
+		$nonce = $request->get_header('X-WP-Nonce');
+		if ( empty( $nonce ) ) {
+			return new WP_Error( 'missing_nonce', 'X-WP-Nonce header is required.', array( 'status' => 401 ) );
+		}
+
+		// Support both logged-in (wp_rest) and logged-out (wp_rest_nonce) nonces
+		$verified = wp_verify_nonce( $nonce, 'wp_rest' );
+		if ( ! $verified ) {
+			$verified = wp_verify_nonce( $nonce, 'wp_rest_nonce' );
+		}
+
+		if ( ! $verified ) {
+			return new WP_Error( 'invalid_nonce', 'Invalid or expired nonce.', array( 'status' => 403 ) );
+		}
+
+		// Rate limiting: max 30 requests per minute per IP
+		$client_ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+		$rate_key  = 'gano_api_ratelimit_' . md5( $client_ip );
+		$now       = time();
+		$window    = 60;
+		$max_req   = 30;
+
+		$requests = get_transient( $rate_key );
+		if ( false === $requests ) {
+			$requests = [];
+		}
+
+		// Clean old entries
+		$requests = array_filter( $requests, fn( $t ) => $t > ( $now - $window ) );
+
+		if ( count( $requests ) >= $max_req ) {
+			return new WP_Error( 'rate_limited', 'Too many requests. Please try again later.', array( 'status' => 429 ) );
+		}
+
+		$requests[] = $now;
+		set_transient( $rate_key, $requests, $window );
+
+		return true;
 	}
 
 	public function handle_chat_request( WP_REST_Request $request ) {

--- a/wp-content/mu-plugins/gano-agent/class-gano-leads-handler.php
+++ b/wp-content/mu-plugins/gano-agent/class-gano-leads-handler.php
@@ -59,9 +59,16 @@ class Gano_Leads_Handler {
 	private static function protect_leads_file() {
 		$htaccess_dir = dirname( self::$leads_file );
 		$htaccess_file = $htaccess_dir . '/.htaccess';
+		$rules = "<Files \"gano-leads.csv\">\n    Require all denied\n</Files>\n";
+		
 		if ( ! file_exists( $htaccess_file ) ) {
-			$rules = "<Files \"gano-leads.csv\">\nOrder Allow,Deny\nDeny from all\n</Files>";
 			@file_put_contents( $htaccess_file, $rules );
+		} else {
+			// Upgrade Apache 2.2 syntax to 2.4 if detected
+			$current = @file_get_contents( $htaccess_file );
+			if ( $current !== false && strpos( $current, 'Order Allow,Deny' ) !== false ) {
+				@file_put_contents( $htaccess_file, $rules );
+			}
 		}
 	}
 }

--- a/wp-content/mu-plugins/gano-agent/class-gano-master-hub.php
+++ b/wp-content/mu-plugins/gano-agent/class-gano-master-hub.php
@@ -2,6 +2,7 @@
 /**
  * Gano Master Operations Hub
  * Centralizes all backlog tools (AI, CRM, Marketing) into a premium UI.
+ * Hardened 2026-04-24: API keys prefer constants in wp-config.php over wp_options.
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -16,6 +17,24 @@ class Gano_Master_Hub {
 
 	public function add_hub_menu() {
 		add_menu_page( 'Gano Hub', 'Gano Hub', 'manage_options', 'gano-master-hub', array( $this, 'render_hub_page' ), 'dashicons-rest-api', 3 );
+	}
+
+	/**
+	 * Retrieve API key securely: prefers wp-config.php constant, falls back to wp_options.
+	 * This prevents keys from being stored in the database where any admin can read them.
+	 */
+	public static function get_ai_api_key() {
+		if (defined('GANO_AI_API_KEY') && !empty(GANO_AI_API_KEY)) {
+			return GANO_AI_API_KEY;
+		}
+		return get_option('gano_ai_api_key', '');
+	}
+
+	public static function get_crm_webhook() {
+		if (defined('GANO_CRM_WEBHOOK') && !empty(GANO_CRM_WEBHOOK)) {
+			return GANO_CRM_WEBHOOK;
+		}
+		return get_option('gano_crm_webhook', '');
 	}
 
 	public function register_hub_settings() {
@@ -42,6 +61,10 @@ class Gano_Master_Hub {
 	}
 
 	public function render_hub_page() {
+		$ai_key = self::get_ai_api_key();
+		$ai_key_from_const = defined('GANO_AI_API_KEY') && !empty(GANO_AI_API_KEY);
+		$crm_url = self::get_crm_webhook();
+		$crm_from_const = defined('GANO_CRM_WEBHOOK') && !empty(GANO_CRM_WEBHOOK);
 		?>
 		<div class="wrap gano-hub-wrap">
 			<div class="hub-header">
@@ -73,7 +96,12 @@ class Gano_Master_Hub {
 							<option value="gemini" <?php selected(get_option('gano_ai_model'), 'gemini'); ?>>Google Gemini Pro 1.5</option>
 						</select>
 						<label>API Key</label>
-						<input type="password" name="gano_ai_api_key" value="<?php echo esc_attr(get_option('gano_ai_api_key')); ?>" class="hub-input" placeholder="sk-...">
+						<input type="password" name="gano_ai_api_key" value="<?php echo esc_attr($ai_key_from_const ? '' : $ai_key); ?>" class="hub-input" placeholder="sk-..." <?php echo $ai_key_from_const ? 'disabled style="opacity:0.5;"' : ''; ?>>
+						<?php if ($ai_key_from_const) : ?>
+							<p style="color:#4ade80;font-size:0.8rem;">🔒 API Key cargada desde wp-config.php (más seguro). Para cambiarla, edita el archivo wp-config.php del servidor.</p>
+						<?php else : ?>
+							<p style="color:#D4AF37;font-size:0.8rem;">⚠️ Recomendado: mueve esta key a wp-config.php como <code>define('GANO_AI_API_KEY', 'sk-...');</code></p>
+						<?php endif; ?>
 						<?php submit_button('Guardar Configuración AI'); ?>
 					</div>
 				</div>
@@ -86,7 +114,10 @@ class Gano_Master_Hub {
 							Configura el flujo de salida de correos transaccionales y la sincronización con CRMs externos (Salesforce/HubSpot).
 						</div>
 						<label>CRM Webhook URL</label>
-						<input type="text" name="gano_crm_webhook" value="<?php echo esc_attr(get_option('gano_crm_webhook')); ?>" class="hub-input" placeholder="https://hooks.zapier.com/...">
+						<input type="text" name="gano_crm_webhook" value="<?php echo esc_attr($crm_from_const ? '' : $crm_url); ?>" class="hub-input" placeholder="https://hooks.zapier.com/..." <?php echo $crm_from_const ? 'disabled style="opacity:0.5;"' : ''; ?>>
+						<?php if ($crm_from_const) : ?>
+							<p style="color:#4ade80;font-size:0.8rem;">🔒 Webhook cargado desde wp-config.php.</p>
+						<?php endif; ?>
 						<p style="font-size:0.8rem;color:#888;">Nota: La infraestructura de cola de correos local está activa para el Onboarding.</p>
 						<?php submit_button('Vincular CRM'); ?>
 					</div>

--- a/wp-content/mu-plugins/gano-agent/gano-reseller-enricher.php
+++ b/wp-content/mu-plugins/gano-agent/gano-reseller-enricher.php
@@ -110,8 +110,13 @@ function gano_enrich_reseller_catalog() {
     }
 }
 
-// Trigger enrichment via URL: /wp-admin/?gano_enrich_reseller=1
+// Trigger enrichment via URL: /wp-admin/?gano_enrich_reseller=1&_wpnonce=<nonce>
+// Generate nonce: wp_create_nonce('gano_enrich_reseller_action')
 if (isset($_GET['gano_enrich_reseller']) && is_admin()) {
+    if (!current_user_can('manage_options') || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'gano_enrich_reseller_action')) {
+        wp_die('Acceso denegado. Se requiere nonce válido y capacidad de administrador.', '403');
+    }
+
     // ─── 2. GLOBALLY ALIGN PRICES (3rd-Year Structure) ───
     if (isset($_GET['gano_align_prices'])) {
         $args = array(

--- a/wp-content/mu-plugins/gano-agent/gano-sota-enricher.php
+++ b/wp-content/mu-plugins/gano-agent/gano-sota-enricher.php
@@ -58,6 +58,11 @@ function gano_enrich_sota_content() {
     }
 }
 // Run once on admin init if requested
+// URL: /wp-admin/?gano_enrich_sota=1&_wpnonce=<nonce>
+// Generate nonce: wp_create_nonce('gano_enrich_sota_action')
 if (isset($_GET['gano_enrich_sota'])) {
+    if (!current_user_can('manage_options') || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'gano_enrich_sota_action')) {
+        wp_die('Acceso denegado. Se requiere nonce válido y capacidad de administrador.', '403');
+    }
     add_action('admin_init', 'gano_enrich_sota_content');
 }

--- a/wp-content/mu-plugins/gano-agent/gano-sota-final-activator.php
+++ b/wp-content/mu-plugins/gano-agent/gano-sota-final-activator.php
@@ -33,6 +33,11 @@ function gano_activate_sota_production() {
     Gano_Agent_Logger::log( "SOTA Final Activator: $count pages published and assigned to V2 template.", 'INFO' );
 }
 
+// URL: /wp-admin/?gano_sota_release_1=1&_wpnonce=<nonce>
+// Generate nonce: wp_create_nonce('gano_sota_release_action')
 if (isset($_GET['gano_sota_release_1'])) {
+    if (!current_user_can('manage_options') || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'gano_sota_release_action')) {
+        wp_die('Acceso denegado. Se requiere nonce válido y capacidad de administrador.', '403');
+    }
     add_action('admin_init', 'gano_activate_sota_production');
 }


### PR DESCRIPTION
## Cambios de seguridad

### 🔴 Críticos
- **receive.php**: secret leído desde $_ENV primero (wp-config como fallback), eliminado exec(), rate limiting por IP (10 req/min), bloqueo de extensiones ejecutables, flush nativo WP
- **Endpoint deploy**: mitigado RCE potencial

### 🟡 Medios
- **Endpoints REST**: eliminado __return_true del MU plugin, unificada protección en tema con nonce + rate limit
- **Enrichers**: añadido wp_verify_nonce() + current_user_can('manage_options') a 3 acciones admin
- **Master Hub**: API keys ahora se leen desde constantes wp-config.php primero, UI indica origen seguro
- **CSV leads**: .htaccess actualizado a sintaxis Apache 2.4 (Require all denied)

### Archivos modificados
- wp-content/gano-deploy/receive.php
- wp-content/mu-plugins/gano-agent/class-gano-agent-api.php
- wp-content/mu-plugins/gano-agent/class-gano-leads-handler.php
- wp-content/mu-plugins/gano-agent/class-gano-master-hub.php
- wp-content/mu-plugins/gano-agent/gano-reseller-enricher.php
- wp-content/mu-plugins/gano-agent/gano-sota-enricher.php
- wp-content/mu-plugins/gano-agent/gano-sota-final-activator.php