### PR TITLE
fix(catalog): PFID numéricos en catalog-sota-v2.js + gitignore fork reseller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,14 @@ agent-orchestrator.yml
 vendor/agentcraft/
 vendor/graphify/
 
+# ─── Plugins de desarrollo local (forks clonados — NO producción) ────────────
+# wp-reseller-store: fork de godaddy/wp-reseller-store para desarrollo local.
+# Registrado como submodule pendiente cuando se habilite en CI.
+wp-content/plugins/wp-reseller-store/
+
+# Alertas Dependabot exportadas vía API (datos en tiempo real, no versionar)
+alerts.json
+
 # Scripts con credenciales — NUNCA commitear
 audit_content.php
 cleanup_content.php


### PR DESCRIPTION
## Resumen

- **Fix crítico de carrito**: El objeto \`PFIDS\` en \`catalog-sota-v2.js\` tenía slugs de texto (\`'wordpress-basic'\`, \`'ssl-deluxe'\`) en lugar de los IDs numéricos que espera la API de GoDaddy — ningún CTA de compra funcionaba.
- **PFIDs corregidos** con los valores del servidor (vía SSH 2026-06-14):
  - \`'pro-managed'\` / \`'business-nvme'\` / \`'ultimate'\` → \`'457'\` (WP Managed familia)
  - \`'whp-expansion'\` → \`'459'\` (Web Hosting Plus)
  - \`'ssl-pro'\` → \`'75'\`
  - \`'email-pro'\` → \`'466'\`
- **\`.gitignore\`**: excluye \`wp-content/plugins/wp-reseller-store/\` (fork clonado localmente de \`Ouroboros1984/wp-reseller-store\`, pendiente de registrar como submodule) y \`alerts.json\` (export de Dependabot API).

## PLID ✅ Confirmado

**PLID \`599667\`** verificado en RCC → Dominios de escaparate:  
URL estándar del escaparate = \`www.secureserver.net?pl_id=599667\`

Las URLs del carrito generadas son:
\`\`\`
https://cart.secureserver.net/?plid=599667&items=%5B%7B%22id%22%3A%22457%22%2C%22quantity%22%3A1%2C%22duration%22%3A12%7D%5D&currencyType=COP&marketId=es-CO
\`\`\`

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| \`wp-content/themes/gano-child/catalog-sota-v2.js\` | PFID slugs → IDs numéricos reales |
| \`wp-content/themes/gano-child/js/catalog-sota-v2.js\` | ídem (copia en \`/js/\`) |
| \`.gitignore\` | excluye fork reseller + alerts.json |

## Test plan

- [ ] Verificar en staging que CTAs de hosting/SSL/email abren \`cart.secureserver.net\` (no WhatsApp ni \`/contacto\`)
- [x] ~~Confirmar PLID correcto en RCC~~ ✅ **Confirmado: 599667**
- [ ] Dependabot sin alertas nuevas tras merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)