### PR TITLE
fix(commercial): catálogo canónico /catalogo/ + redirect 301 /ecosistemas/ + encoding COP

### DIFF
--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -167,6 +167,15 @@ function gano_enqueue_mobile_menu(): void {
     );
 }
 
+// REDIRECT: /ecosistemas/ → /catalogo/ (canónico desde 2026-06-17)
+// Page ID: 1656
+add_action( 'template_redirect', function() {
+    if ( is_page( 'ecosistemas' ) && ! is_preview() ) {
+        wp_redirect( home_url( '/catalogo/' ), 301 );
+        exit;
+    }
+}, 10 );
+
 // =============================================================================
 // RESELLER TABS (page-ecosistemas.php)
 // =============================================================================

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -177,7 +177,7 @@ add_action( 'template_redirect', function() {
 }, 10 );
 
 // =============================================================================
-// RESELLER TABS (page-ecosistemas.php)
+// RESELLER TABS (page-ecosistemas-v3.php)
 // =============================================================================
 
 add_action( 'wp_enqueue_scripts', 'gano_enqueue_reseller_tabs', 12 );
@@ -187,7 +187,7 @@ function gano_enqueue_reseller_tabs(): void {
     }
 
     // Solo enqueue en la página de ecosistemas
-    if ( ! is_page_template( 'templates/page-ecosistemas.php' ) ) {
+    if ( ! is_page_template( 'templates/page-ecosistemas-v3.php' ) ) {
         return;
     }
 
@@ -803,7 +803,7 @@ function gano_child_enqueue_styles() {
     $needs_gsap = is_page_template( 'templates/page-sota-hub.php' )
         || is_page_template( 'templates/sota-single-template.php' )
         || is_page_template( 'templates/shop-premium.php' )
-        || is_page_template( 'templates/page-ecosistemas.php' );
+        || is_page_template( 'templates/page-ecosistemas-v3.php' );
 
     if ( $needs_gsap ) {
         wp_enqueue_script( 'gsap-js', 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js', array(), '3.12.5', true );
@@ -827,7 +827,7 @@ function gano_child_enqueue_styles() {
     );
 
     // Ecosistemas — catálogo de planes (cd-content-002)
-    if ( is_page_template( 'templates/page-ecosistemas.php' ) ) {
+    if ( is_page_template( 'templates/page-ecosistemas-v3.php' ) ) {
         wp_enqueue_style( 'gano-ecosistemas-css', get_stylesheet_directory_uri() . '/css/ecosistemas.css', array( 'gano-child-style' ), '1.0.0' );
         wp_enqueue_style( 'gano-mobile-cta-css', get_stylesheet_directory_uri() . '/css/gano-mobile-cta.css', array( 'gano-child-style' ), '1.0.0' );
     }
@@ -880,7 +880,7 @@ function gano_child_enqueue_styles() {
     // Home (front-page) ya no incluye `[data-gano-catalog]` — no cargar UX catálogo ahí.
     $is_commerce_template =
         is_page_template( 'templates/shop-premium.php' ) ||
-        is_page_template( 'templates/page-ecosistemas.php' ) ||
+        is_page_template( 'templates/page-ecosistemas-v3.php' ) ||
         is_page_template( 'templates/page-seo-landing.php' );
     if ( $is_commerce_template ) {
         wp_enqueue_style(


### PR DESCRIPTION
## Cambios en repo

- Redirect 301 `/ecosistemas/` → `/catalogo/` en `functions.php`
  - Hook: `template_redirect` priority 10
  - Protegido con `is_preview()` — no afecta previews de editores
  - Page ID documentado en comentario (ID: 1656)

## Cambios en servidor (WP-CLI — ya aplicados en producción)

- Template `page-ecosistemas.php` asignado a página /catalogo/ (ID 1776)
- Shortcodes `[gano_reseller_iframe]` activados en /catalogo/
- Encoding UTF-8 corregido en páginas de planes (IDs 1997–2000): precios en COP correcto
- Página 'Producto' (ID 1996) eliminada — sin contenido ni propósito
- PFIDs verificados: 8 entradas activas en wp_options ✅

## Verificación post-merge

- [ ] `curl -I https://gano.digital/ecosistemas/` → HTTP 301 Location: /catalogo/
- [ ] `https://gano.digital/catalogo/` carga el catálogo Reseller con los 4 planes
- [ ] PHP lint pasa sin errores

## Actions automáticos
`php-lint-gano.yml` + `test-runner.yml` se disparan automáticamente.