### PR TITLE
fix(dominios): habilitar compra de dominios — CSP + botones TLD

### DIFF
--- a/wp-content/mu-plugins/gano-security.php
+++ b/wp-content/mu-plugins/gano-security.php
@@ -337,6 +337,8 @@ add_action( 'send_headers', function() {
         //   • upgrade-insecure-requests fuerza HTTPS en todos los sub-recursos.
         //   • frame-src incluye reseller.godaddy.com para el carrito Reseller (Fase 4).
         //   • frame-src incluye reseller-store.godaddy.com para iframe embebido Reseller Store (Fase 4).
+        //   • connect-src incluye storefront/cart.secureserver.net para la búsqueda de dominios (rstore widget).
+        //   • frame-src incluye cart.secureserver.net para el checkout de dominios GoDaddy Reseller.
         //
         $csp = implode( '; ', [
             "default-src 'self'",
@@ -344,8 +346,8 @@ add_action( 'send_headers', function() {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "font-src 'self' data: https://fonts.gstatic.com",
             "img-src 'self' data: https:",
-            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com",
-            "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com",
+            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com https://storefront.secureserver.net https://cart.secureserver.net",
+            "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com https://cart.secureserver.net",
             "upgrade-insecure-requests",
             "report-uri /wp-json/gano/v1/csp-report",
         ] );

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -18,7 +18,7 @@ get_header();
     </section>
 
     <!-- BUSCADOR DE DOMINIOS -->
-    <section class="dominios-search-section">
+    <section id="dominios-search" class="dominios-search-section">
         <h2 class="dominios-search-title">Busca tu Dominio Ideal</h2>
         <div class="search-container">
             <?php echo do_shortcode('[rstore_domain_search page_size="5"]'); ?>
@@ -33,55 +33,83 @@ get_header();
             $tlds = [
                 [
                     'extension' => '.CO',
-                    'nombre' => 'Colombia',
-                    'precio' => '$90.000',
-                    'desc' => 'Presencia nacional de máxima autoridad',
+                    'tld'       => 'co',
+                    'nombre'    => 'Colombia',
+                    'precio'    => '$90.000',
+                    'desc'      => 'Presencia nacional de máxima autoridad',
                 ],
                 [
                     'extension' => '.COM',
-                    'nombre' => 'Global',
-                    'precio' => '$75.000',
-                    'desc' => 'El estándar internacional de credibilidad',
+                    'tld'       => 'com',
+                    'nombre'    => 'Global',
+                    'precio'    => '$75.000',
+                    'desc'      => 'El estándar internacional de credibilidad',
                 ],
                 [
                     'extension' => '.NET',
-                    'nombre' => 'Infraestructura',
-                    'precio' => '$85.000',
-                    'desc' => 'La red técnica de confianza',
+                    'tld'       => 'net',
+                    'nombre'    => 'Infraestructura',
+                    'precio'    => '$85.000',
+                    'desc'      => 'La red técnica de confianza',
                 ],
                 [
                     'extension' => '.TECH',
-                    'nombre' => 'Tecnología',
-                    'precio' => '$160.000',
-                    'desc' => 'Para startups e innovadores',
+                    'tld'       => 'tech',
+                    'nombre'    => 'Tecnología',
+                    'precio'    => '$160.000',
+                    'desc'      => 'Para startups e innovadores',
                 ],
                 [
                     'extension' => '.BIZ',
-                    'nombre' => 'Negocio',
-                    'precio' => '$110.000',
-                    'desc' => 'Enfoque operativo y profesional',
+                    'tld'       => 'biz',
+                    'nombre'    => 'Negocio',
+                    'precio'    => '$110.000',
+                    'desc'      => 'Enfoque operativo y profesional',
                 ],
                 [
                     'extension' => '.AI',
-                    'nombre' => 'Inteligencia Artificial',
-                    'precio' => '$350.000',
-                    'desc' => 'La frontera de la innovación',
+                    'tld'       => 'ai',
+                    'nombre'    => 'Inteligencia Artificial',
+                    'precio'    => '$350.000',
+                    'desc'      => 'La frontera de la innovación',
                 ],
             ];
 
             foreach ($tlds as $tld) {
                 ?>
-                <div class="tld-card">
+                <div class="tld-card" data-tld="<?php echo esc_attr($tld['tld']); ?>">
                     <h3><?php echo esc_html($tld['extension']); ?></h3>
                     <div class="tld-price"><?php echo esc_html($tld['precio']); ?><small>/año</small></div>
                     <p class="tld-description"><?php echo esc_html($tld['desc']); ?></p>
-                    <a href="#" class="tld-button">Registrar</a>
+                    <a href="#dominios-search"
+                       class="tld-button"
+                       data-tld="<?php echo esc_attr($tld['tld']); ?>"
+                       aria-label="Registrar dominio <?php echo esc_attr($tld['extension']); ?>">
+                        Registrar
+                    </a>
                 </div>
                 <?php
             }
             ?>
         </div>
     </section>
+
+    <!-- TLD pre-fill: cuando el usuario hace clic en un botón TLD, rellena el input del buscador -->
+    <script>
+    (function () {
+        document.querySelectorAll('.tld-button[data-tld]').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var tld = btn.getAttribute('data-tld');
+                // El widget rstore renderiza un input[type=text] dentro de .rstore-domain-search
+                var input = document.querySelector('.rstore-domain-search input[type="text"]');
+                if (input && tld) {
+                    input.value = 'midominio.' + tld;
+                    input.focus();
+                }
+            });
+        });
+    })();
+    </script>
 
     <!-- CTA FINAL -->
     <section class="dominios-cta-final">


### PR DESCRIPTION
## Problema

La página `/dominios/` no permitía comprar dominios por dos razones:

1. **CSP demasiado restrictiva** — `connect-src` bloqueaba las peticiones XHR del widget `rstore_domain_search` hacia `storefront.secureserver.net` (API de disponibilidad) y `cart.secureserver.net` (checkout). El browser cancelaba silenciosamente la búsqueda.

2. **Botones TLD sin destino** — los 6 botones "Registrar" en las tarjetas de TLD (.CO, .COM, .NET, .TECH, .BIZ, .AI) tenían `href="#"` y no llevaban al buscador ni al carrito.

## Cambios

### `gano-security.php` (MU Plugin CSP)
- `connect-src`: agrega `https://storefront.secureserver.net` y `https://cart.secureserver.net`
- `frame-src`: agrega `https://cart.secureserver.net` para el iframe de checkout de dominios

### `page-dominios.php`
- Sección de búsqueda recibe `id="dominios-search"` como anchor
- Botones TLD: `href="#"` → `href="#dominios-search"` + `data-tld` + `aria-label`
- JS inline: al hacer clic en un TLD, pre-rellena el input del buscador con `midominio.{tld}` y hace focus

## Test plan
- [ ] Ir a `gano.digital/dominios/`
- [ ] Buscar un dominio en el widget — debe mostrar disponibilidad y botón "Agregar al carrito"
- [ ] Hacer clic en "Registrar" de cualquier tarjeta TLD → debe scrollear al buscador con el TLD pre-rellenado
- [ ] Completar una compra de dominio de prueba en el carrito GoDaddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)