### PR TITLE
fix(csp): permitir cdnjs.cloudflare.com para Font Awesome en Catálogo SOTA v2

### DIFF
--- a/wp-content/mu-plugins/gano-security.php
+++ b/wp-content/mu-plugins/gano-security.php
@@ -343,8 +343,8 @@ add_action( 'send_headers', function() {
         $csp = implode( '; ', [
             "default-src 'self'",
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com https://www.googletagmanager.com https://ajax.googleapis.com https://cdnjs.cloudflare.com",
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-            "font-src 'self' data: https://fonts.gstatic.com",
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com",
+            "font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com",
             "img-src 'self' data: https:",
             "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com https://storefront.secureserver.net https://cart.secureserver.net",
             "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com https://cart.secureserver.net",


### PR DESCRIPTION
## Resumen

- Agrega `https://cdnjs.cloudflare.com` a `style-src` en el CSP
- Agrega `https://cdnjs.cloudflare.com` a `font-src` en el CSP

## Por qué

El template `shop-premium.php` (Catálogo SOTA v2) carga Font Awesome desde `cdnjs.cloudflare.com`. El CSP ya permitía ese dominio en `script-src` (para GSAP 3), pero bloqueaba la hoja de estilo y los archivos de fuente de Font Awesome, dejando los íconos sin renderizar.

## Archivos modificados

- `wp-content/mu-plugins/gano-security.php` — 2 líneas en el bloque CSP

## Test plan

- [ ] Cambiar template de `/catalogo/` a "Catálogo SOTA v2" en WP Admin
- [ ] Verificar que los íconos Font Awesome se renderizan (fa-microchip, fa-bolt, fa-crown, etc.)
- [ ] Confirmar que no hay errores CSP en consola del navegador
- [ ] Confirmar que `/dominios/` sigue funcionando (no toca esa lógica)

🤖 Generated with [Claude Code](https://claude.com/claude-code)