### PR TITLE
fix(ci): corregir referencia stale page-ecosistemas.php en workflow 32

### DIFF
--- a/.github/workflows/32-commerce-release-sequence.yml
+++ b/.github/workflows/32-commerce-release-sequence.yml
@@ -24,7 +24,7 @@ jobs:
           php -l wp-content/themes/gano-child/functions.php
           php -l wp-content/themes/gano-child/front-page.php
           php -l wp-content/themes/gano-child/templates/shop-premium.php
-          php -l wp-content/themes/gano-child/templates/page-ecosistemas.php
+          php -l wp-content/themes/gano-child/templates/page-ecosistemas-v3.php
           php -l wp-content/themes/gano-child/templates/page-seo-landing.php
           php -l wp-content/themes/gano-child/templates/page-sota-hub.php
           php -l wp-content/themes/gano-child/templates/page-diagnostico-digital.php


### PR DESCRIPTION
## Resumen

El workflow `32 · Release · Commerce Sequence` fallaba con `No such file or directory` porque referenciaba `templates/page-ecosistemas.php`, eliminado en la ola ops del 2026-04-19.

**Cambio**: una línea — actualiza el lint check a `page-ecosistemas-v3.php`.

## Impacto

Sin este fix, dispatch manual del workflow 32 (commerce release sequence) siempre falla en el primer job. Con el fix, el pipeline completo puede ejecutarse para validar un release comercial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)