### PR TITLE
fix(audit): 4 correcciones técnicas post-auditoría masiva

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,8 +105,11 @@ jobs:
           mkdir -p "$TMPDIR/wp-content/plugins"
           mkdir -p "$TMPDIR/wp-content/mu-plugins"
 
-          # Copy theme
+          # Copy theme (excluir carpetas de desarrollo que no van a producción)
           cp -r wp-content/themes/gano-child "$TMPDIR/wp-content/themes/"
+          rm -rf "$TMPDIR/wp-content/themes/gano-child/archive"
+          rm -f  "$TMPDIR/wp-content/themes/gano-child/front-page-draft.php"
+          rm -f  "$TMPDIR/wp-content/themes/gano-child/front-page.backup-"*.php
 
           # Copy MU plugins
           cp wp-content/mu-plugins/gano-*.php "$TMPDIR/wp-content/mu-plugins/" 2>/dev/null || true

--- a/wp-content/themes/gano-child/catalog-sota-v2.css
+++ b/wp-content/themes/gano-child/catalog-sota-v2.css
@@ -9,7 +9,10 @@
 /* ══════════════════════════════════════════════════════
    1. VARIABLES CSS
 ══════════════════════════════════════════════════════ */
-:root {
+/* Scoped con :has() — solo activa cuando shop-premium.php está en página.
+   Evita que el tema dark del catálogo contamine otras páginas del sitio. */
+:root:has(#catalog-main),
+:root:has([data-gano-catalog]) {
   --gano-bg:          #0a0a0f;
   --gano-surface:     #12121c;
   --gano-card:        #16162a;

--- a/wp-content/themes/gano-child/front-page.php
+++ b/wp-content/themes/gano-child/front-page.php
@@ -526,9 +526,9 @@ $url_login = wp_login_url( home_url() );
 					<h4><?php esc_html_e( 'Empresa', 'gano-child' ); ?></h4>
 					<ul>
 						<li><a href="<?php echo esc_url( home_url( '/nosotros/' ) ); ?>"><?php esc_html_e( 'Sobre nosotros', 'gano-child' ); ?></a></li>
-						<li><a href="#"><?php esc_html_e( 'Estado de red', 'gano-child' ); ?></a></li>
+						<li><a href="https://status.godaddy.com/" target="_blank" rel="noopener"><?php esc_html_e( 'Estado de red', 'gano-child' ); ?></a></li>
 						<li><a href="<?php echo esc_url( home_url( '/blog/' ) ); ?>"><?php esc_html_e( 'Blog', 'gano-child' ); ?></a></li>
-						<li><a href="#"><?php esc_html_e( 'Preguntas frecuentes', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( home_url( '/comenzar-aqui/' ) ); ?>"><?php esc_html_e( 'Preguntas frecuentes', 'gano-child' ); ?></a></li>
 						<li><a href="<?php echo esc_url( home_url( '/contacto/' ) ); ?>"><?php esc_html_e( 'Contacto', 'gano-child' ); ?></a></li>
 					</ul>
 				</div>
@@ -538,7 +538,7 @@ $url_login = wp_login_url( home_url() );
 					<ul>
 						<li><a href="<?php echo esc_url( home_url( '/terminos/' ) ); ?>"><?php esc_html_e( 'Términos y condiciones', 'gano-child' ); ?></a></li>
 						<li><a href="<?php echo esc_url( home_url( '/privacidad/' ) ); ?>"><?php esc_html_e( 'Política de privacidad', 'gano-child' ); ?></a></li>
-						<li><a href="#"><?php esc_html_e( 'Política de uso', 'gano-child' ); ?></a></li>
+						<li><a href="<?php echo esc_url( home_url( '/terminos/' ) ); ?>"><?php esc_html_e( 'Política de uso', 'gano-child' ); ?></a></li>
 						<li><a href="<?php echo esc_url( home_url( '/sla/' ) ); ?>"><?php esc_html_e( 'SLA', 'gano-child' ); ?></a></li>
 					</ul>
 				</div>

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -59,21 +59,25 @@ function gano_enqueue_premium_styles() {
         '1.0.0'
     );
 
-    // CSS de ecosistemas (mejorado)
-    wp_enqueue_style(
-        'gano-ecosistemas',
-        get_stylesheet_directory_uri() . '/css/ecosistemas.css',
-        array(),
-        '1.0.0'
-    );
+    // CSS de ecosistemas — solo en templates que lo necesitan
+    if ( is_page_template( 'templates/page-ecosistemas-v3.php' ) || is_page( 'ecosistemas' ) || is_page( 'catalogo' ) ) {
+        wp_enqueue_style(
+            'gano-ecosistemas',
+            get_stylesheet_directory_uri() . '/css/ecosistemas.css',
+            array(),
+            '1.0.0'
+        );
+    }
 
-    // CSS de página Dominios
-    wp_enqueue_style(
-        'gano-dominios',
-        get_stylesheet_directory_uri() . '/css/dominios.css',
-        array(),
-        '1.0.0'
-    );
+    // CSS de página Dominios — solo en esa página
+    if ( is_page_template( 'templates/page-dominios.php' ) || is_page( 'dominios' ) ) {
+        wp_enqueue_style(
+            'gano-dominios',
+            get_stylesheet_directory_uri() . '/css/dominios.css',
+            array(),
+            '1.0.0'
+        );
+    }
 
     // CSS de CTA Registro (Fase 2)
     wp_enqueue_style(
@@ -813,7 +817,10 @@ function gano_child_enqueue_styles() {
         // Gano SOTA FX Handler (The "Vivid & Animated" Experience)
         wp_enqueue_script( 'gano-sota-fx', get_stylesheet_directory_uri() . '/js/gano-sota-fx.js', array( 'gsap-scroll-trigger' ), '1.0.0', true );
     }
-    wp_enqueue_style( 'gano-sota-animations', get_stylesheet_directory_uri() . '/gano-sota-animations.css', array(), '2.0.0' );
+    // SOTA animations — solo en páginas con animaciones complejas, no globalmente
+    if ( is_front_page() || $needs_gsap ) {
+        wp_enqueue_style( 'gano-sota-animations', get_stylesheet_directory_uri() . '/gano-sota-animations.css', array(), '2.0.0' );
+    }
 
     // Constellation — HUD base (chips, paneles) con motion tokens unificados
     wp_enqueue_style( 'gano-constellation', get_stylesheet_directory_uri() . '/css/gano-constellation.css', array( 'gano-child-style' ), '1.0.0' );


### PR DESCRIPTION
## Resumen

Resultado de la auditoría masiva del 2026-06-18. 4 correcciones en un solo PR.

### 1. CSS tokens scoped — `catalog-sota-v2.css`
**Problema:** `:root { --gano-bg: #0a0a0f }` en el catálogo sobrescribía los tokens del design system global en todas las páginas.  
**Fix:** Usa `:root:has(#catalog-main)` — los tokens dark del catálogo solo activan cuando `shop-premium.php` está en pantalla. Sin cambios en ningún otro selector.

### 2. Footer dead links — `front-page.php`
**Problema:** "Estado de red", "Preguntas frecuentes" y "Política de uso" apuntaban a `#`.  
**Fix:**
- Estado de red → `https://status.godaddy.com/` (externo)
- Preguntas frecuentes → `/comenzar-aqui/` (tiene FAQ Schema markup)
- Política de uso → `/terminos/` (redirige a la página legal existente)
- Redes sociales quedan como `#` (Diego proveerá URLs)

### 3. CSS condicional — `functions.php`
**Problema:** `ecosistemas.css` (~45KB), `dominios.css` y `gano-sota-animations.css` se cargaban en **todas** las páginas del sitio.  
**Fix:** Guards `is_page_template()` / `is_page()` para cargar cada CSS solo donde aplica.

### 4. Deploy limpio — `deploy.yml`
**Problema:** La carpeta `archive/` (versiones viejas de templates) y backups `.php` se deployaban a producción.  
**Fix:** `rm -rf` de `archive/`, `front-page-draft.php` y `front-page.backup-*.php` del ZIP antes de enviar.

## Test plan
- [ ] Verificar que `/catalogo/` sigue con tema dark correcto (CSS scoping no rompió nada)
- [ ] Verificar que footer de homepage tiene los links correctos
- [ ] Verificar que `/ecosistemas/` y otras páginas sin catálogo no cargan ecosistemas.css
- [ ] Siguiente deploy: confirmar que archive/ no aparece en servidor

🤖 Generated with [Claude Code](https://claude.com/claude-code)