### PR TITLE
fix(dominios): reparar buscador — CSP secureserver.net + hero text + TLD prefill

### DIFF
--- a/wp-content/mu-plugins/gano-security.php
+++ b/wp-content/mu-plugins/gano-security.php
@@ -337,8 +337,15 @@ add_action( 'send_headers', function() {
         //   • upgrade-insecure-requests fuerza HTTPS en todos los sub-recursos.
         //   • frame-src incluye reseller.godaddy.com para el carrito Reseller (Fase 4).
         //   • frame-src incluye reseller-store.godaddy.com para iframe embebido Reseller Store (Fase 4).
-        //   • connect-src incluye storefront/cart.secureserver.net para la búsqueda de dominios (rstore widget).
-        //   • frame-src incluye cart.secureserver.net para el checkout de dominios GoDaddy Reseller.
+        //   • connect-src incluye *.secureserver.net completo para el rstore plugin (class-api.php):
+        //       - www.secureserver.net/api/v1/          → búsqueda disponibilidad de dominios
+        //       - www.secureserver.net/api/v1/cart/{pl} → carrito reseller
+        //       - gui.secureserver.net                  → GUI JSON (header/footer assets)
+        //       - sso.secureserver.net                  → autenticación GoDaddy
+        //       - account.secureserver.net              → cuenta GoDaddy
+        //       - storefront.secureserver.net           → catálogo reseller
+        //       - cart.secureserver.net                 → checkout
+        //   • frame-src incluye www.secureserver.net para modal de checkout GoDaddy.
         //
         $csp = implode( '; ', [
             "default-src 'self'",
@@ -346,8 +353,8 @@ add_action( 'send_headers', function() {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com",
             "font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com",
             "img-src 'self' data: https:",
-            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com https://storefront.secureserver.net https://cart.secureserver.net",
-            "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com https://cart.secureserver.net",
+            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com https://www.secureserver.net https://storefront.secureserver.net https://cart.secureserver.net https://gui.secureserver.net https://sso.secureserver.net https://account.secureserver.net",
+            "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com https://www.secureserver.net https://cart.secureserver.net",
             "upgrade-insecure-requests",
             "report-uri /wp-json/gano/v1/csp-report",
         ] );

--- a/wp-content/themes/gano-child/css/dominios.css
+++ b/wp-content/themes/gano-child/css/dominios.css
@@ -36,7 +36,9 @@
     text-align: center;
     max-width: 900px;
     margin-bottom: 20px;
-    animation: fadeInUp 1s ease-out 0.3s both;
+    color: #f1f5f9;
+    /* animation sin delay y sin fill-mode 'both' para evitar quedarse en opacity:0 */
+    animation: dominiosHeroFadeUp 0.8s ease-out forwards;
 }
 
 .dominios-hero p {
@@ -45,12 +47,24 @@
     text-align: center;
     max-width: 600px;
     margin: 0 auto 50px;
-    animation: fadeInUp 1s ease-out 0.6s both;
+    animation: dominiosHeroFadeUp 0.8s ease-out 0.2s forwards;
+    opacity: 0;
 }
 
-@keyframes fadeInUp {
-    from { opacity: 0; transform: translateY(40px); }
-    to { opacity: 1; transform: translateY(0); }
+/* Keyframes únicos para dominios (evita colisión con fadeInUp global) */
+@keyframes dominiosHeroFadeUp {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Accesibilidad: respetar preferencia de movimiento reducido */
+@media (prefers-reduced-motion: reduce) {
+    .dominios-hero h1,
+    .dominios-hero p {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
 }
 
 /* BUSCADOR SECTION */

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -6,22 +6,36 @@
  */
 
 get_header();
+
+// Pre-fill del parámetro ?domain=X: el rstore plugin lo procesa en JS, pero capturarlo
+// en PHP permite pre-cargar el valor en el atributo data-domain para búsqueda inmediata.
+$searched_domain = isset( $_GET['domain'] ) ? sanitize_text_field( wp_unslash( $_GET['domain'] ) ) : '';
 ?>
 
 <main class="dominios-page">
     <!-- HERO -->
     <section class="dominios-hero">
         <div class="hero-content">
-            <h1>Tu Identidad Digital Comienza Aquí</h1>
-            <p>Busca, registra y gestiona dominios con la máxima libertad. Precios en COP, soporte en español y control total.</p>
+            <h1><?php esc_html_e( 'Tu Identidad Digital Comienza Aquí', 'gano-child' ); ?></h1>
+            <p><?php esc_html_e( 'Busca, registra y gestiona dominios con la máxima libertad. Precios en COP, soporte en español y control total.', 'gano-child' ); ?></p>
         </div>
     </section>
 
     <!-- BUSCADOR DE DOMINIOS -->
     <section id="dominios-search" class="dominios-search-section">
-        <h2 class="dominios-search-title">Busca tu Dominio Ideal</h2>
+        <h2 class="dominios-search-title"><?php esc_html_e( 'Busca tu Dominio Ideal', 'gano-child' ); ?></h2>
+        <?php if ( $searched_domain ) : ?>
+            <p class="dominios-search-hint"><?php printf( esc_html__( 'Resultados para: %s', 'gano-child' ), '<strong>' . esc_html( $searched_domain ) . '</strong>' ); ?></p>
+        <?php endif; ?>
         <div class="search-container">
-            <?php echo do_shortcode('[rstore_domain_search page_size="5"]'); ?>
+            <?php
+            // Pasa el dominio buscado como atributo extra para que el widget JS lo use
+            $shortcode_atts = 'page_size="5"';
+            if ( $searched_domain ) {
+                $shortcode_atts .= ' domain="' . esc_attr( $searched_domain ) . '"';
+            }
+            echo do_shortcode( '[rstore_domain_search ' . $shortcode_atts . ']' );
+            ?>
         </div>
     </section>
 
@@ -88,17 +102,29 @@ get_header();
         </div>
     </section>
 
-    <!-- TLD pre-fill: cuando el usuario hace clic en un botón TLD, rellena el input del buscador -->
+    <!-- TLD pre-fill: clic en card TLD → rellena buscador + dispara búsqueda + scroll -->
     <script>
     (function () {
         document.querySelectorAll('.tld-button[data-tld]').forEach(function (btn) {
-            btn.addEventListener('click', function () {
-                var tld = btn.getAttribute('data-tld');
-                // El widget rstore renderiza un input[type=text] dentro de .rstore-domain-search
+            btn.addEventListener('click', function (e) {
+                e.preventDefault();
+                var tld   = btn.getAttribute('data-tld');
                 var input = document.querySelector('.rstore-domain-search input[type="text"]');
-                if (input && tld) {
-                    input.value = 'midominio.' + tld;
-                    input.focus();
+                if ( ! input || ! tld ) { return; }
+
+                input.value = 'midominio.' + tld;
+                input.focus();
+
+                // Intentar enviar el formulario del widget rstore para disparar la búsqueda
+                var form = input.closest('form');
+                if ( form ) {
+                    form.dispatchEvent( new Event('submit', { bubbles: true, cancelable: true }) );
+                }
+
+                // Scroll suave al buscador
+                var section = document.getElementById('dominios-search');
+                if ( section ) {
+                    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }
             });
         });


### PR DESCRIPTION
## Causa raíz

El widget `[rstore_domain_search]` (plugin `reseller-store`) hace llamadas XHR a `https://www.secureserver.net/api/v1/` para verificar disponibilidad de dominios. Ese dominio **no estaba en `connect-src`** del CSP → las respuestas se bloqueaban silenciosamente → el form enviaba (`?domain=X` en URL) pero los resultados nunca aparecían.

Diagnóstico obtenido leyendo directamente `class-api.php` del plugin:
```php
$this->urls['api']  = 'https://www.secureserver.net/api/v1/';
$this->urls['gui']  = 'https://gui.secureserver.net/pcjson/standardheaderfooter';
$this->urls['sso']  = 'https://sso.secureserver.net/';
// ...
```

## Cambios

### `gano-security.php` — CSP
Agrega a `connect-src`: `www.secureserver.net`, `gui.secureserver.net`, `sso.secureserver.net`, `account.secureserver.net`  
Agrega a `frame-src`: `www.secureserver.net`

### `css/dominios.css` — hero text
- Keyframe renombrado a `dominiosHeroFadeUp` (evita colisión con `fadeInUp` global)
- `color: #f1f5f9` explícito en `h1` (no dependía de herencia potencialmente rota)
- `animation: forwards` en lugar de `both` → el texto ya no se queda en `opacity:0` si la animación falla
- `@media (prefers-reduced-motion: reduce)` → animación desactivada, `opacity:1` forzado

### `page-dominios.php` — PHP + JS
- Captura de `$_GET['domain']` sanitizado → pasado al shortcode como `domain="X"`
- Hint visual "Resultados para: X" cuando hay búsqueda activa
- JS botones TLD: dispara `form.submit()` + scroll suave al buscador

## Test plan
- [ ] Buscar un dominio en `/dominios/` → deben aparecer resultados debajo del input
- [ ] `gano.digital/dominios/?domain=miempresa` → resultados cargados directamente
- [ ] Clic en botón ".CO" → input se llena con `midominio.co`, busca y hace scroll
- [ ] Hero de la página de dominios: texto visible inmediatamente (sin fade-in invisible)
- [ ] Abrir DevTools → Console → sin errores CSP bloqueados

🤖 Generated with [Claude Code](https://claude.com/claude-code)