### PR TITLE
fix(dominios): proxy PHP server-side — elimina CORS en búsqueda de dominios

### DIFF
--- a/wp-content/mu-plugins/gano-security.php
+++ b/wp-content/mu-plugins/gano-security.php
@@ -337,8 +337,15 @@ add_action( 'send_headers', function() {
         //   • upgrade-insecure-requests fuerza HTTPS en todos los sub-recursos.
         //   • frame-src incluye reseller.godaddy.com para el carrito Reseller (Fase 4).
         //   • frame-src incluye reseller-store.godaddy.com para iframe embebido Reseller Store (Fase 4).
-        //   • connect-src incluye storefront/cart.secureserver.net para la búsqueda de dominios (rstore widget).
-        //   • frame-src incluye cart.secureserver.net para el checkout de dominios GoDaddy Reseller.
+        //   • connect-src incluye *.secureserver.net completo para el rstore plugin (class-api.php):
+        //       - www.secureserver.net/api/v1/          → búsqueda disponibilidad de dominios
+        //       - www.secureserver.net/api/v1/cart/{pl} → carrito reseller
+        //       - gui.secureserver.net                  → GUI JSON (header/footer assets)
+        //       - sso.secureserver.net                  → autenticación GoDaddy
+        //       - account.secureserver.net              → cuenta GoDaddy
+        //       - storefront.secureserver.net           → catálogo reseller
+        //       - cart.secureserver.net                 → checkout
+        //   • frame-src incluye www.secureserver.net para modal de checkout GoDaddy.
         //
         $csp = implode( '; ', [
             "default-src 'self'",
@@ -346,8 +353,8 @@ add_action( 'send_headers', function() {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com",
             "font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com",
             "img-src 'self' data: https:",
-            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com https://storefront.secureserver.net https://cart.secureserver.net",
-            "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com https://cart.secureserver.net",
+            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://api.godaddy.com https://myh.godaddy.com https://www.secureserver.net https://storefront.secureserver.net https://cart.secureserver.net https://gui.secureserver.net https://sso.secureserver.net https://account.secureserver.net",
+            "frame-src 'self' https://reseller.godaddy.com https://reseller-store.godaddy.com https://www.godaddy.com https://www.secureserver.net https://cart.secureserver.net",
             "upgrade-insecure-requests",
             "report-uri /wp-json/gano/v1/csp-report",
         ] );

--- a/wp-content/themes/gano-child/css/dominios.css
+++ b/wp-content/themes/gano-child/css/dominios.css
@@ -67,6 +67,131 @@
     }
 }
 
+/* ─── BUSCADOR PROPIO (proxy PHP — sin CORS) ─── */
+.gano-domain-form { width: 100%; }
+
+.gano-domain-input-wrap {
+    display: flex;
+    gap: 0;
+    border-radius: 14px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    transition: border-color 0.2s ease;
+}
+.gano-domain-input-wrap:focus-within {
+    border-color: var(--gc-primary);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.gano-domain-input {
+    flex: 1;
+    padding: 18px 22px;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #f1f5f9;
+    font-size: 1.05rem;
+    font-family: inherit;
+}
+.gano-domain-input::placeholder { color: #64748b; }
+
+.gano-domain-btn {
+    padding: 18px 32px;
+    background: linear-gradient(135deg, var(--gc-primary), var(--gc-secondary));
+    color: #fff;
+    border: none;
+    font-weight: 700;
+    font-size: 1rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.2s ease;
+    min-width: 110px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+.gano-domain-btn:hover:not(:disabled) { opacity: 0.88; }
+.gano-domain-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.gano-domain-btn__spinner {
+    width: 16px; height: 16px;
+    border: 2px solid rgba(255,255,255,0.35);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: domainSpin 0.7s linear infinite;
+}
+@keyframes domainSpin {
+    to { transform: rotate(360deg); }
+}
+
+/* Resultados */
+.gano-domain-results { margin-top: 28px; text-align: left; }
+.gano-domain-searching { color: #94a3b8; text-align: center; padding: 20px 0; }
+.gano-domain-error { color: #f87171; text-align: center; padding: 20px 0; }
+
+.gano-domain-list {
+    list-style: none;
+    margin: 0; padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.gano-domain-item {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 20px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    flex-wrap: wrap;
+}
+.gano-domain-item--exact {
+    border-color: rgba(27, 79, 216, 0.4);
+    background: rgba(27, 79, 216, 0.06);
+}
+
+.gano-domain-item__name {
+    flex: 1;
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: #f1f5f9;
+    word-break: break-all;
+}
+
+.gano-domain-item__badge {
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 4px 10px;
+    border-radius: 20px;
+    white-space: nowrap;
+}
+.gano-domain-item__badge--ok  { background: rgba(0,194,107,0.18); color: #00C26B; }
+.gano-domain-item__badge--no  { background: rgba(248,113,113,0.18); color: #f87171; }
+
+.gano-domain-item__cta {
+    padding: 8px 18px;
+    background: linear-gradient(135deg, var(--gc-primary), var(--gc-secondary));
+    color: #fff;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 0.85rem;
+    white-space: nowrap;
+    transition: opacity 0.2s;
+}
+.gano-domain-item__cta:hover { opacity: 0.85; }
+
+@media (max-width: 600px) {
+    .gano-domain-input-wrap { flex-direction: column; border-radius: 12px; }
+    .gano-domain-btn { border-radius: 0 0 12px 12px; width: 100%; padding: 14px; }
+    .gano-domain-input { border-radius: 12px 12px 0 0; }
+    .gano-domain-item { flex-wrap: wrap; gap: 8px; }
+}
+
 /* BUSCADOR SECTION */
 .dominios-search-section {
     padding: 80px 5%;

--- a/wp-content/themes/gano-child/css/dominios.css
+++ b/wp-content/themes/gano-child/css/dominios.css
@@ -36,7 +36,9 @@
     text-align: center;
     max-width: 900px;
     margin-bottom: 20px;
-    animation: fadeInUp 1s ease-out 0.3s both;
+    color: #f1f5f9;
+    /* animation sin delay y sin fill-mode 'both' para evitar quedarse en opacity:0 */
+    animation: dominiosHeroFadeUp 0.8s ease-out forwards;
 }
 
 .dominios-hero p {
@@ -45,12 +47,24 @@
     text-align: center;
     max-width: 600px;
     margin: 0 auto 50px;
-    animation: fadeInUp 1s ease-out 0.6s both;
+    animation: dominiosHeroFadeUp 0.8s ease-out 0.2s forwards;
+    opacity: 0;
 }
 
-@keyframes fadeInUp {
-    from { opacity: 0; transform: translateY(40px); }
-    to { opacity: 1; transform: translateY(0); }
+/* Keyframes únicos para dominios (evita colisión con fadeInUp global) */
+@keyframes dominiosHeroFadeUp {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Accesibilidad: respetar preferencia de movimiento reducido */
+@media (prefers-reduced-motion: reduce) {
+    .dominios-hero h1,
+    .dominios-hero p {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
 }
 
 /* BUSCADOR SECTION */

--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -3293,3 +3293,98 @@ function gano_enqueue_ecosystems_v3() {
 	);
 }
 add_action( 'wp_enqueue_scripts', 'gano_enqueue_ecosystems_v3', 11 );
+
+// =============================================================================
+// DOMAIN SEARCH PROXY — /wp-json/gano/v1/domains/search?q=X&pageSize=5
+//
+// GoDaddy no tiene CORS habilitado en www.secureserver.net/api/v1/domains/
+// para dominios de reseller. El JS del widget domain-search.min.js falla con
+// "Failed to fetch" cuando intenta llamar directamente desde el browser.
+//
+// Este proxy hace la llamada server-side (PHP → GoDaddy API) y devuelve el
+// JSON al browser desde el mismo origen (gano.digital), eliminando el CORS.
+// =============================================================================
+
+add_action( 'rest_api_init', 'gano_register_domain_search_proxy' );
+
+function gano_register_domain_search_proxy(): void {
+    register_rest_route(
+        'gano/v1',
+        '/domains/search',
+        array(
+            'methods'             => WP_REST_Server::READABLE,
+            'callback'            => 'gano_domain_search_proxy_callback',
+            'permission_callback' => '__return_true',
+            'args'                => array(
+                'q'        => array(
+                    'required'          => true,
+                    'sanitize_callback' => 'sanitize_text_field',
+                    'validate_callback' => function ( $v ) {
+                        return is_string( $v ) && strlen( trim( $v ) ) >= 1 && strlen( $v ) <= 255;
+                    },
+                ),
+                'pageSize' => array(
+                    'default'           => 5,
+                    'sanitize_callback' => 'absint',
+                ),
+            ),
+        )
+    );
+}
+
+function gano_domain_search_proxy_callback( WP_REST_Request $request ): WP_REST_Response {
+    // PLID: leer del plugin reseller-store; fallback hardcoded para el caso en que
+    // el plugin aún no esté activo o rstore_get_option() no esté disponible.
+    $plid = 0;
+    if ( function_exists( 'rstore_get_option' ) ) {
+        $plid = (int) rstore_get_option( 'pl_id' );
+    }
+    if ( $plid <= 0 ) {
+        $plid = (int) get_option( 'rstore_pl_id', 599667 );
+    }
+    if ( $plid <= 0 ) {
+        $plid = 599667; // PLID Gano Digital hard-coded como último fallback
+    }
+
+    $q         = trim( (string) $request->get_param( 'q' ) );
+    $page_size = min( (int) $request->get_param( 'pageSize' ), 10 );
+
+    $api_url = add_query_arg(
+        array(
+            'q'        => $q,
+            'pageSize' => $page_size,
+        ),
+        sprintf( 'https://www.secureserver.net/api/v1/domains/%d/', $plid )
+    );
+
+    $response = wp_remote_get(
+        $api_url,
+        array(
+            'timeout' => 12,
+            'headers' => array(
+                'Accept'     => 'application/json',
+                'User-Agent' => 'GanoDigital-DomainSearch/1.0 (+https://gano.digital)',
+            ),
+        )
+    );
+
+    if ( is_wp_error( $response ) ) {
+        return new WP_REST_Response(
+            array(
+                'error'   => 'Domain lookup temporarily unavailable.',
+                'details' => $response->get_error_message(),
+            ),
+            502
+        );
+    }
+
+    $http_code = (int) wp_remote_retrieve_response_code( $response );
+    $body      = wp_remote_retrieve_body( $response );
+    $data      = json_decode( $body, true );
+
+    if ( null === $data ) {
+        return new WP_REST_Response( array( 'error' => 'Invalid API response.' ), 502 );
+    }
+
+    return new WP_REST_Response( $data, $http_code );
+}

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -7,9 +7,23 @@
 
 get_header();
 
-// Pre-fill del parámetro ?domain=X: el rstore plugin lo procesa en JS, pero capturarlo
-// en PHP permite pre-cargar el valor en el atributo data-domain para búsqueda inmediata.
-$searched_domain = isset( $_GET['domain'] ) ? sanitize_text_field( wp_unslash( $_GET['domain'] ) ) : '';
+// Dominio pre-cargado desde ?domain=X (vía formulario o botón TLD)
+$initial_domain = isset( $_GET['domain'] ) ? sanitize_text_field( wp_unslash( $_GET['domain'] ) ) : '';
+
+// PLID del reseller para construir URLs de carrito
+$plid = 0;
+if ( function_exists( 'rstore_get_option' ) ) {
+    $plid = (int) rstore_get_option( 'pl_id' );
+}
+if ( $plid <= 0 ) {
+    $plid = (int) get_option( 'rstore_pl_id', 599667 );
+}
+if ( $plid <= 0 ) {
+    $plid = 599667;
+}
+
+// URL del proxy: /wp-json/gano/v1/domains/search
+$proxy_url = rest_url( 'gano/v1/domains/search' );
 ?>
 
 <main class="dominios-page">
@@ -24,19 +38,146 @@ $searched_domain = isset( $_GET['domain'] ) ? sanitize_text_field( wp_unslash( $
     <!-- BUSCADOR DE DOMINIOS -->
     <section id="dominios-search" class="dominios-search-section">
         <h2 class="dominios-search-title"><?php esc_html_e( 'Busca tu Dominio Ideal', 'gano-child' ); ?></h2>
-        <?php if ( $searched_domain ) : ?>
-            <p class="dominios-search-hint"><?php printf( esc_html__( 'Resultados para: %s', 'gano-child' ), '<strong>' . esc_html( $searched_domain ) . '</strong>' ); ?></p>
-        <?php endif; ?>
+
         <div class="search-container">
-            <?php
-            // Pasa el dominio buscado como atributo extra para que el widget JS lo use
-            $shortcode_atts = 'page_size="5"';
-            if ( $searched_domain ) {
-                $shortcode_atts .= ' domain="' . esc_attr( $searched_domain ) . '"';
-            }
-            echo do_shortcode( '[rstore_domain_search ' . $shortcode_atts . ']' );
-            ?>
+            <!-- Formulario propio — llama al proxy PHP en lugar de GoDaddy directamente
+                 (GoDaddy no tiene CORS en www.secureserver.net para dominios reseller) -->
+            <form id="gano-domain-form" class="gano-domain-form" autocomplete="off">
+                <div class="gano-domain-input-wrap">
+                    <input
+                        type="text"
+                        id="gano-domain-input"
+                        class="gano-domain-input"
+                        placeholder="<?php esc_attr_e( 'Encuentra tu dominio perfecto', 'gano-child' ); ?>"
+                        value="<?php echo esc_attr( $initial_domain ); ?>"
+                        maxlength="253"
+                        autocomplete="off"
+                        spellcheck="false"
+                        aria-label="<?php esc_attr_e( 'Nombre de dominio a buscar', 'gano-child' ); ?>"
+                    />
+                    <button type="submit" class="gano-domain-btn" id="gano-domain-submit">
+                        <span class="gano-domain-btn__text"><?php esc_html_e( 'Buscar', 'gano-child' ); ?></span>
+                        <span class="gano-domain-btn__spinner" aria-hidden="true" hidden></span>
+                    </button>
+                </div>
+            </form>
+
+            <!-- Área de resultados — renderizada por JS -->
+            <div id="gano-domain-results" class="gano-domain-results" role="region" aria-live="polite" aria-label="<?php esc_attr_e( 'Resultados de búsqueda de dominio', 'gano-child' ); ?>"></div>
         </div>
+
+        <script>
+        (function () {
+            'use strict';
+
+            var PROXY_URL  = <?php echo wp_json_encode( esc_url_raw( $proxy_url ) ); ?>;
+            var PLID       = <?php echo (int) $plid; ?>;
+            var CART_BASE  = 'https://cart.secureserver.net/go/domainstep';
+
+            var form       = document.getElementById('gano-domain-form');
+            var input      = document.getElementById('gano-domain-input');
+            var submitBtn  = document.getElementById('gano-domain-submit');
+            var btnText    = submitBtn ? submitBtn.querySelector('.gano-domain-btn__text') : null;
+            var btnSpinner = submitBtn ? submitBtn.querySelector('.gano-domain-btn__spinner') : null;
+            var results    = document.getElementById('gano-domain-results');
+
+            if ( ! form || ! input || ! results ) { return; }
+
+            // Auto-buscar si hay dominio pre-cargado desde ?domain=X
+            var initialDomain = input.value.trim();
+            if ( initialDomain.length > 0 ) {
+                searchDomain( initialDomain );
+            }
+
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                var q = input.value.trim();
+                if ( q.length < 1 ) { return; }
+                searchDomain( q );
+            });
+
+            function setLoading( loading ) {
+                if ( loading ) {
+                    if ( btnText )    { btnText.hidden    = true; }
+                    if ( btnSpinner ) { btnSpinner.hidden = false; }
+                    if ( submitBtn )  { submitBtn.disabled = true; }
+                    results.innerHTML = '<p class="gano-domain-searching"><?php echo esc_js( __( 'Consultando disponibilidad…', 'gano-child' ) ); ?></p>';
+                } else {
+                    if ( btnText )    { btnText.hidden    = false; }
+                    if ( btnSpinner ) { btnSpinner.hidden = true; }
+                    if ( submitBtn )  { submitBtn.disabled = false; }
+                }
+            }
+
+            function cartUrl( fqdn ) {
+                return CART_BASE + '?plid=' + PLID + '&domain=' + encodeURIComponent( fqdn );
+            }
+
+            function renderResults( data ) {
+                if ( ! data || ( ! data.exactMatchDomain && ! data.suggestedDomains ) ) {
+                    results.innerHTML = '<p class="gano-domain-error"><?php echo esc_js( __( 'No se encontraron resultados. Intenta con otro nombre.', 'gano-child' ) ); ?></p>';
+                    return;
+                }
+
+                var html = '<ul class="gano-domain-list">';
+
+                // Resultado exacto primero
+                if ( data.exactMatchDomain ) {
+                    var d   = data.exactMatchDomain;
+                    var avail = d.available === true || d.available === 'true';
+                    html += '<li class="gano-domain-item gano-domain-item--exact ' + ( avail ? 'is-available' : 'is-taken' ) + '">';
+                    html += '<span class="gano-domain-item__name">' + escHtml( d.fqdn ) + '</span>';
+                    if ( avail ) {
+                        html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
+                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( d.fqdn ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
+                    } else {
+                        html += '<span class="gano-domain-item__badge gano-domain-item__badge--no"><?php echo esc_js( __( 'No disponible', 'gano-child' ) ); ?></span>';
+                    }
+                    html += '</li>';
+                }
+
+                // Sugerencias
+                if ( data.suggestedDomains && data.suggestedDomains.length ) {
+                    data.suggestedDomains.forEach( function (d) {
+                        var avail = d.available === true || d.available === 'true';
+                        if ( ! avail ) { return; } // solo mostrar disponibles en sugerencias
+                        html += '<li class="gano-domain-item is-available">';
+                        html += '<span class="gano-domain-item__name">' + escHtml( d.fqdn ) + '</span>';
+                        html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
+                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( d.fqdn ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
+                        html += '</li>';
+                    });
+                }
+
+                html += '</ul>';
+                results.innerHTML = html;
+            }
+
+            function searchDomain( q ) {
+                setLoading( true );
+                fetch( PROXY_URL + '?q=' + encodeURIComponent(q) + '&pageSize=5' )
+                    .then( function(r) { return r.json(); } )
+                    .then( function(data) {
+                        setLoading( false );
+                        if ( data && data.error ) {
+                            results.innerHTML = '<p class="gano-domain-error">' + escHtml( data.error ) + '</p>';
+                        } else {
+                            renderResults( data );
+                        }
+                    })
+                    .catch( function() {
+                        setLoading( false );
+                        results.innerHTML = '<p class="gano-domain-error"><?php echo esc_js( __( 'No se pudo verificar la disponibilidad. Intenta de nuevo.', 'gano-child' ) ); ?></p>';
+                    });
+            }
+
+            function escHtml( str ) {
+                return String(str)
+                    .replace(/&/g,'&amp;').replace(/</g,'&lt;')
+                    .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+            }
+        })();
+        </script>
     </section>
 
     <!-- TLDS POPULARES -->
@@ -102,30 +243,32 @@ $searched_domain = isset( $_GET['domain'] ) ? sanitize_text_field( wp_unslash( $
         </div>
     </section>
 
-    <!-- TLD pre-fill: clic en card TLD → rellena buscador + dispara búsqueda + scroll -->
+    <!-- TLD pre-fill: clic en card → rellena buscador propio + dispara búsqueda + scroll -->
     <script>
     (function () {
         document.querySelectorAll('.tld-button[data-tld]').forEach(function (btn) {
             btn.addEventListener('click', function (e) {
                 e.preventDefault();
                 var tld   = btn.getAttribute('data-tld');
-                var input = document.querySelector('.rstore-domain-search input[type="text"]');
+                var input = document.getElementById('gano-domain-input');
+                var form  = document.getElementById('gano-domain-form');
                 if ( ! input || ! tld ) { return; }
 
                 input.value = 'midominio.' + tld;
-                input.focus();
-
-                // Intentar enviar el formulario del widget rstore para disparar la búsqueda
-                var form = input.closest('form');
-                if ( form ) {
-                    form.dispatchEvent( new Event('submit', { bubbles: true, cancelable: true }) );
-                }
 
                 // Scroll suave al buscador
                 var section = document.getElementById('dominios-search');
                 if ( section ) {
                     section.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }
+
+                // Pequeño delay para que el scroll complete, luego disparar búsqueda
+                setTimeout(function () {
+                    if ( form ) {
+                        form.dispatchEvent( new Event('submit', { bubbles: true, cancelable: true }) );
+                    }
+                    input.focus();
+                }, 400 );
             });
         });
     })();

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -6,22 +6,36 @@
  */
 
 get_header();
+
+// Pre-fill del parámetro ?domain=X: el rstore plugin lo procesa en JS, pero capturarlo
+// en PHP permite pre-cargar el valor en el atributo data-domain para búsqueda inmediata.
+$searched_domain = isset( $_GET['domain'] ) ? sanitize_text_field( wp_unslash( $_GET['domain'] ) ) : '';
 ?>
 
 <main class="dominios-page">
     <!-- HERO -->
     <section class="dominios-hero">
         <div class="hero-content">
-            <h1>Tu Identidad Digital Comienza Aquí</h1>
-            <p>Busca, registra y gestiona dominios con la máxima libertad. Precios en COP, soporte en español y control total.</p>
+            <h1><?php esc_html_e( 'Tu Identidad Digital Comienza Aquí', 'gano-child' ); ?></h1>
+            <p><?php esc_html_e( 'Busca, registra y gestiona dominios con la máxima libertad. Precios en COP, soporte en español y control total.', 'gano-child' ); ?></p>
         </div>
     </section>
 
     <!-- BUSCADOR DE DOMINIOS -->
     <section id="dominios-search" class="dominios-search-section">
-        <h2 class="dominios-search-title">Busca tu Dominio Ideal</h2>
+        <h2 class="dominios-search-title"><?php esc_html_e( 'Busca tu Dominio Ideal', 'gano-child' ); ?></h2>
+        <?php if ( $searched_domain ) : ?>
+            <p class="dominios-search-hint"><?php printf( esc_html__( 'Resultados para: %s', 'gano-child' ), '<strong>' . esc_html( $searched_domain ) . '</strong>' ); ?></p>
+        <?php endif; ?>
         <div class="search-container">
-            <?php echo do_shortcode('[rstore_domain_search page_size="5"]'); ?>
+            <?php
+            // Pasa el dominio buscado como atributo extra para que el widget JS lo use
+            $shortcode_atts = 'page_size="5"';
+            if ( $searched_domain ) {
+                $shortcode_atts .= ' domain="' . esc_attr( $searched_domain ) . '"';
+            }
+            echo do_shortcode( '[rstore_domain_search ' . $shortcode_atts . ']' );
+            ?>
         </div>
     </section>
 
@@ -88,17 +102,29 @@ get_header();
         </div>
     </section>
 
-    <!-- TLD pre-fill: cuando el usuario hace clic en un botón TLD, rellena el input del buscador -->
+    <!-- TLD pre-fill: clic en card TLD → rellena buscador + dispara búsqueda + scroll -->
     <script>
     (function () {
         document.querySelectorAll('.tld-button[data-tld]').forEach(function (btn) {
-            btn.addEventListener('click', function () {
-                var tld = btn.getAttribute('data-tld');
-                // El widget rstore renderiza un input[type=text] dentro de .rstore-domain-search
+            btn.addEventListener('click', function (e) {
+                e.preventDefault();
+                var tld   = btn.getAttribute('data-tld');
                 var input = document.querySelector('.rstore-domain-search input[type="text"]');
-                if (input && tld) {
-                    input.value = 'midominio.' + tld;
-                    input.focus();
+                if ( ! input || ! tld ) { return; }
+
+                input.value = 'midominio.' + tld;
+                input.focus();
+
+                // Intentar enviar el formulario del widget rstore para disparar la búsqueda
+                var form = input.closest('form');
+                if ( form ) {
+                    form.dispatchEvent( new Event('submit', { bubbles: true, cancelable: true }) );
+                }
+
+                // Scroll suave al buscador
+                var section = document.getElementById('dominios-search');
+                if ( section ) {
+                    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }
             });
         });


### PR DESCRIPTION
## Causa raíz

El widget `domain-search.min.js` v4.0.1 del plugin `reseller-store` llama directamente desde el browser a `https://www.secureserver.net/api/v1/domains/{plid}/`. GoDaddy **no tiene CORS habilitado** en ese endpoint para resellers externos → browser lanza `TypeError: Failed to fetch`.

Confirmado inspeccionando el JS minificado:
```js
t = "https://www.".concat(baseUrl, "/api/v1/domains/").concat(plid, "/")
```

El CSP en `connect-src` fue necesario pero insuficiente: el problema es CORS, no CSP.

## Solución

Proxy PHP WordPress REST API en `functions.php`:
- `GET /wp-json/gano/v1/domains/search?q=X&pageSize=5`
- PHP hace `wp_remote_get()` a GoDaddy (server-to-server, sin CORS)
- Retorna JSON al browser desde `gano.digital` (mismo origen)

Reemplaza `[rstore_domain_search]` con formulario propio + JS que usa el proxy.

## Archivos

| Archivo | Cambio |
|---------|--------|
| `functions.php` | `gano_register_domain_search_proxy()` — endpoint REST proxy |
| `templates/page-dominios.php` | Formulario propio + JS IIFE + renderResults() |
| `css/dominios.css` | Estilos completos del nuevo buscador |

## Test plan
- [ ] Buscar "miempresa" → resultados con badge Disponible/No disponible en < 3s
- [ ] Buscar dominio disponible → botón "Registrar →" abre cart.secureserver.net con el dominio
- [ ] `/dominios/?domain=miempresa` → auto-busca al cargar la página
- [ ] Clic en botón ".CO" → input se llena con `midominio.co` y busca automáticamente
- [ ] Sin errores en consola del browser
- [ ] Hero text visible al cargar (CSS animation fix del commit anterior)

Cierra PR #339 (supersedido por este).

🤖 Generated with [Claude Code](https://claude.com/claude-code)