### PR TITLE
fix(dominios): campo domain correcto + plan hosting en CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,16 +24,24 @@ real de hosting WordPress en Colombia. Workspace: esta carpeta raíz del proyect
 | **SEO** | MU `gano-seo.php` activo; Rank Math **instalado, inactivo** hasta cerrar copy |
 | **Tema padre** | Hello Elementor (child: gano-child) |
 | **UX** | Chat IA (gano-chat.js) + Quiz Soberanía Digital |
-| **Hosting actual** | **Managed WordPress Deluxe** (plan activo del servidor donde corre gano.digital) |
+| **Hosting actual** | **Web Hosting Deluxe** (cPanel — plan activo del servidor donde corre gano.digital) |
 
-## Infraestructura del servidor (Managed WordPress Deluxe)
-Plan actual donde está alojado gano.digital. Relevante para saber qué tenemos disponible:
-- 20 GB NVMe total storage
-- CDN incluido (hasta 2x más rápido)
-- Protección DDoS
-- Staging site disponible ← útil para probar cambios antes de subir a producción
-- Subdomains permitidos ✅ — my.gano.digital, support.gano.digital pueden crearse en este mismo plan; **ops.gano.digital** puede apuntar al Ops Hub (GitHub Pages o carpeta estática) — ver `memory/ops/gano-ops-hub-deployment.md`
-- **Implicación Fase 4**: El staging site permite probar cambios de vitrina, Reseller y plugins antes de producción. Los subdomains van en este mismo plan cuando apliquen.
+## Infraestructura del servidor (Web Hosting Deluxe — cPanel)
+Plan confirmado el 2026-06-18. **No** es Managed WordPress — es hosting cPanel estándar con WordPress instalado.
+- **Panel**: cPanel (acceso completo — File Manager, Terminal, Node.js Selector, etc.)
+- 50 GB NVMe storage
+- 10 sitios web en un mismo plan
+- Dominio gratis incluido
+- Correo gratis incluido
+- SSL gratuito e ilimitado para todos los sitios
+- CDN incluido
+- Garantía de devolución 30 días
+- **No tiene staging site built-in** (era feature de Managed WP) — staging vía rama/deploy workflow
+- **SSH disponible** vía cPanel → Terminal (habilitar en cPanel si no está activo)
+- **Node.js Selector** disponible en cPanel → permite instalar Claude CLI directamente en el servidor
+- Subdomains permitidos ✅ — my.gano.digital, support.gano.digital, ops.gano.digital
+
+⚠️ Todo el historial previo que mencione "Managed WordPress Deluxe" o "staging site" debe interpretarse con este contexto correcto.
 
 ## Términos clave
 | Término | Significado |

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -122,14 +122,18 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                 var html = '<ul class="gano-domain-list">';
 
                 // Resultado exacto primero
+                // GoDaddy API usa el campo 'domain' (no 'fqdn')
+                function getDomainName(d) { return d.domain || d.fqdn || d.domainName || ''; }
+
                 if ( data.exactMatchDomain ) {
-                    var d   = data.exactMatchDomain;
+                    var d     = data.exactMatchDomain;
+                    var dName = getDomainName(d);
                     var avail = d.available === true || d.available === 'true';
                     html += '<li class="gano-domain-item gano-domain-item--exact ' + ( avail ? 'is-available' : 'is-taken' ) + '">';
-                    html += '<span class="gano-domain-item__name">' + escHtml( d.fqdn ) + '</span>';
+                    html += '<span class="gano-domain-item__name">' + escHtml( dName ) + '</span>';
                     if ( avail ) {
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
-                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( d.fqdn ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
+                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( dName ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
                     } else {
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--no"><?php echo esc_js( __( 'No disponible', 'gano-child' ) ); ?></span>';
                     }
@@ -139,12 +143,13 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                 // Sugerencias
                 if ( data.suggestedDomains && data.suggestedDomains.length ) {
                     data.suggestedDomains.forEach( function (d) {
+                        var dName = getDomainName(d);
                         var avail = d.available === true || d.available === 'true';
-                        if ( ! avail ) { return; } // solo mostrar disponibles en sugerencias
+                        if ( ! avail ) { return; }
                         html += '<li class="gano-domain-item is-available">';
-                        html += '<span class="gano-domain-item__name">' + escHtml( d.fqdn ) + '</span>';
+                        html += '<span class="gano-domain-item__name">' + escHtml( dName ) + '</span>';
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
-                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( d.fqdn ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
+                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( dName ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
                         html += '</li>';
                     });
                 }


### PR DESCRIPTION
## Cambios

### 1. Buscador de dominios — campo `domain` en lugar de `fqdn`
**Problema:** Los resultados mostraban "undefined" como nombre de dominio.
**Causa:** La API de GoDaddy devuelve el campo `domain` (no `fqdn`).  
**Fix:** `getDomainName(d)` con fallback: `d.domain || d.fqdn || d.domainName`

### 2. CLAUDE.md — plan de hosting correcto
El plan real es **Web Hosting Deluxe (cPanel)**, no Managed WordPress Deluxe.
- cPanel disponible (Terminal, Node.js Selector, File Manager)
- 50 GB NVMe, 10 sitios, SSL ilimitado
- SSH disponible
- Sin staging site built-in

## Test plan
- [ ] Buscar "miempresa" → resultado muestra "miempresa.com" (no "undefined")
- [ ] Botón "Registrar →" incluye el nombre correcto del dominio en la URL del carrito

🤖 Generated with [Claude Code](https://claude.com/claude-code)