### PR TITLE
fix(dominios): proxy PHP carrito GoDaddy — corrige error al registrar dominio

### DIFF
--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -3388,3 +3388,97 @@ function gano_domain_search_proxy_callback( WP_REST_Request $request ): WP_REST_
 
     return new WP_REST_Response( $data, $http_code );
 }
+
+// =============================================================================
+// DOMAIN CART PROXY — POST /wp-json/gano/v1/domains/cart
+//
+// El widget rstore agrega dominios al carrito via POST server-side:
+// POST https://www.secureserver.net/api/v1/cart/{plid}/?redirect=true
+// Body: [{"id":"domain","domain":"miempresa.com"}]
+// Respuesta: {"nextStepUrl":"https://cart.secureserver.net/..."}
+//
+// Sin este proxy el browser no puede hacer ese POST (CORS bloqueado).
+// =============================================================================
+
+add_action( 'rest_api_init', 'gano_register_domain_cart_proxy' );
+
+function gano_register_domain_cart_proxy(): void {
+    register_rest_route(
+        'gano/v1',
+        '/domains/cart',
+        array(
+            'methods'             => WP_REST_Server::CREATABLE,
+            'callback'            => 'gano_domain_cart_proxy_callback',
+            'permission_callback' => '__return_true',
+            'args'                => array(
+                'domain' => array(
+                    'required'          => true,
+                    'sanitize_callback' => 'sanitize_text_field',
+                    'validate_callback' => function ( $v ) {
+                        return is_string( $v ) && strlen( trim( $v ) ) >= 3 && strlen( $v ) <= 255;
+                    },
+                ),
+            ),
+        )
+    );
+}
+
+function gano_domain_cart_proxy_callback( WP_REST_Request $request ): WP_REST_Response {
+    $plid = 0;
+    if ( function_exists( 'rstore_get_option' ) ) {
+        $plid = (int) rstore_get_option( 'pl_id' );
+    }
+    if ( $plid <= 0 ) {
+        $plid = (int) get_option( 'rstore_pl_id', 599667 );
+    }
+    if ( $plid <= 0 ) {
+        $plid = 599667;
+    }
+
+    $domain = trim( (string) $request->get_param( 'domain' ) );
+
+    // Payload exacto que usa domain-search.min.js v4.0.1
+    $items = wp_json_encode( array( array( 'id' => 'domain', 'domain' => $domain ) ) );
+
+    $cart_url = sprintf(
+        'https://www.secureserver.net/api/v1/cart/%d/?redirect=true',
+        $plid
+    );
+
+    $response = wp_remote_post(
+        $cart_url,
+        array(
+            'timeout' => 12,
+            'headers' => array(
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json',
+                'User-Agent'   => 'GanoDigital-DomainCart/1.0 (+https://gano.digital)',
+            ),
+            'body' => $items,
+        )
+    );
+
+    if ( is_wp_error( $response ) ) {
+        return new WP_REST_Response(
+            array( 'error' => 'Cart temporarily unavailable.', 'details' => $response->get_error_message() ),
+            502
+        );
+    }
+
+    $http_code = (int) wp_remote_retrieve_response_code( $response );
+    $body      = wp_remote_retrieve_body( $response );
+    $data      = json_decode( $body, true );
+
+    // Si la API devuelve nextStepUrl, usarla directamente
+    if ( ! empty( $data['nextStepUrl'] ) ) {
+        return new WP_REST_Response( array( 'redirectUrl' => $data['nextStepUrl'] ), 200 );
+    }
+
+    // Fallback: construir URL de resultados de dominio en GoDaddy
+    $fallback = add_query_arg(
+        array( 'plid' => $plid, 'keyword' => $domain ),
+        'https://www.secureserver.net/domains/registration/results.aspx'
+    );
+
+    return new WP_REST_Response( array( 'redirectUrl' => $fallback ), 200 );
+}

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -71,8 +71,7 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
             'use strict';
 
             var PROXY_URL  = <?php echo wp_json_encode( esc_url_raw( $proxy_url ) ); ?>;
-            var PLID       = <?php echo (int) $plid; ?>;
-            var CART_BASE  = 'https://cart.secureserver.net/go/domainstep';
+            var CART_URL   = <?php echo wp_json_encode( esc_url_raw( rest_url( 'gano/v1/domains/cart' ) ) ); ?>;
 
             var form       = document.getElementById('gano-domain-form');
             var input      = document.getElementById('gano-domain-input');
@@ -125,6 +124,12 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                 // GoDaddy API usa el campo 'domain' (no 'fqdn')
                 function getDomainName(d) { return d.domain || d.fqdn || d.domainName || ''; }
 
+                // Botón de carrito: llama al proxy PHP que hace POST a GoDaddy cart API
+                function makeCartBtn( dName ) {
+                    return '<button class="gano-domain-item__cta" data-domain="' + escHtml(dName) + '">'
+                        + '<?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></button>';
+                }
+
                 if ( data.exactMatchDomain ) {
                     var d     = data.exactMatchDomain;
                     var dName = getDomainName(d);
@@ -133,7 +138,7 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                     html += '<span class="gano-domain-item__name">' + escHtml( dName ) + '</span>';
                     if ( avail ) {
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
-                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( dName ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
+                        html += makeCartBtn( dName );
                     } else {
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--no"><?php echo esc_js( __( 'No disponible', 'gano-child' ) ); ?></span>';
                     }
@@ -149,13 +154,41 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                         html += '<li class="gano-domain-item is-available">';
                         html += '<span class="gano-domain-item__name">' + escHtml( dName ) + '</span>';
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
-                        html += '<a class="gano-domain-item__cta" href="' + escHtml( cartUrl( dName ) ) + '" target="_blank" rel="noopener"><?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></a>';
+                        html += makeCartBtn( dName );
                         html += '</li>';
                     });
                 }
 
                 html += '</ul>';
                 results.innerHTML = html;
+
+                // Vincular botones de carrito — POST al proxy PHP → redirect a GoDaddy
+                results.querySelectorAll('.gano-domain-item__cta[data-domain]').forEach( function(btn) {
+                    btn.addEventListener('click', function() {
+                        var domain = btn.getAttribute('data-domain');
+                        btn.disabled = true;
+                        btn.textContent = '<?php echo esc_js( __( 'Abriendo…', 'gano-child' ) ); ?>';
+
+                        fetch( CART_URL, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ domain: domain })
+                        })
+                        .then( function(r) { return r.json(); } )
+                        .then( function(data) {
+                            if ( data && data.redirectUrl ) {
+                                window.open( data.redirectUrl, '_blank', 'noopener' );
+                            } else {
+                                btn.disabled = false;
+                                btn.textContent = '<?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?>';
+                            }
+                        })
+                        .catch( function() {
+                            btn.disabled = false;
+                            btn.textContent = '<?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?>';
+                        });
+                    });
+                });
             }
 
             function searchDomain( q ) {


### PR DESCRIPTION
## Problema

El botón "Registrar →" generaba error porque apuntaba a `cart.secureserver.net/go/domainstep` — URL incorrecta para registro de dominios en el Reseller Store.

## Causa confirmada (leyendo domain-search.min.js v4.0.1)

El widget rstore usa:
```
POST https://www.secureserver.net/api/v1/cart/{plid}/?redirect=true
Body: [{"id":"domain","domain":"miempresa.com"}]
Response: {"nextStepUrl":"https://cart.secureserver.net/..."}
```

Este POST tampoco funciona desde el browser (CORS bloqueado).

## Solución

**Nuevo endpoint:** `POST /wp-json/gano/v1/domains/cart`
- PHP hace el POST a GoDaddy cart API server-side
- Devuelve `redirectUrl` al browser
- Fallback a página de resultados de dominio si la API falla

**JS actualizado:**
- Botones son `<button data-domain>` en lugar de `<a href>`
- Click → fetch POST al proxy → `window.open(redirectUrl, '_blank')`
- Estado "Abriendo…" mientras espera respuesta

## Test plan
- [ ] Buscar "miempresa" → click "Registrar →" en dominio disponible
- [ ] Se abre pestaña nueva con carrito de GoDaddy con el dominio pre-cargado
- [ ] Sin errores en consola del browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)