### PR TITLE
fix(dominios): carrito — redirect directo + precios COP en resultados

### DIFF
--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -3472,50 +3472,16 @@ function gano_domain_cart_proxy_callback( WP_REST_Request $request ): WP_REST_Re
         $plid = 599667;
     }
 
-    $domain = trim( (string) $request->get_param( 'domain' ) );
+    $domain     = strtolower( trim( (string) $request->get_param( 'domain' ) ) );
+    $product_id = absint( $request->get_param( 'productId' ) );
 
-    // Payload exacto que usa domain-search.min.js v4.0.1
-    $items = wp_json_encode( array( array( 'id' => 'domain', 'domain' => $domain ) ) );
-
-    $cart_url = sprintf(
-        'https://www.secureserver.net/api/v1/cart/%d/?redirect=true',
-        $plid
-    );
-
-    $response = wp_remote_post(
-        $cart_url,
-        array(
-            'timeout' => 12,
-            'headers' => array(
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json',
-                'User-Agent'   => 'GanoDigital-DomainCart/1.0 (+https://gano.digital)',
-            ),
-            'body' => $items,
-        )
-    );
-
-    if ( is_wp_error( $response ) ) {
-        return new WP_REST_Response(
-            array( 'error' => 'Cart temporarily unavailable.', 'details' => $response->get_error_message() ),
-            502
-        );
-    }
-
-    $http_code = (int) wp_remote_retrieve_response_code( $response );
-    $body      = wp_remote_retrieve_body( $response );
-    $data      = json_decode( $body, true );
-
-    // Si la API devuelve nextStepUrl, usarla directamente
-    if ( ! empty( $data['nextStepUrl'] ) ) {
-        return new WP_REST_Response( array( 'redirectUrl' => $data['nextStepUrl'] ), 200 );
-    }
-
-    // Fallback: construir URL de resultados de dominio en GoDaddy
-    $fallback = add_query_arg(
+    // Construir URL de registro directa — sin POST a GoDaddy (requiere cookies de sesión
+    // que el servidor no puede proveer). La página de resultados lleva al usuario al flujo
+    // completo de registro con el dominio pre-seleccionado.
+    $redirect_url = add_query_arg(
         array( 'plid' => $plid, 'keyword' => $domain ),
         'https://www.secureserver.net/domains/registration/results.aspx'
     );
 
-    return new WP_REST_Response( array( 'redirectUrl' => $fallback ), 200 );
+    return new WP_REST_Response( array( 'redirectUrl' => $redirect_url ), 200 );
 }

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -124,10 +124,11 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                 // GoDaddy API usa el campo 'domain' (no 'fqdn')
                 function getDomainName(d) { return d.domain || d.fqdn || d.domainName || ''; }
 
-                // Botón de carrito: llama al proxy PHP que hace POST a GoDaddy cart API
-                function makeCartBtn( dName ) {
-                    return '<button class="gano-domain-item__cta" data-domain="' + escHtml(dName) + '">'
-                        + '<?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?></button>';
+                // Botón de carrito con precio real de la API
+                function makeCartBtn( dName, price, productId ) {
+                    var priceHtml = price ? ' <span class="gano-domain-item__price">' + escHtml(price) + '</span>' : '';
+                    return '<button class="gano-domain-item__cta" data-domain="' + escHtml(dName) + '" data-pid="' + escHtml(String(productId||'')) + '">'
+                        + '<?php echo esc_js( __( 'Registrar →', 'gano-child' ) ); ?>' + priceHtml + '</button>';
                 }
 
                 if ( data.exactMatchDomain ) {
@@ -138,7 +139,7 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                     html += '<span class="gano-domain-item__name">' + escHtml( dName ) + '</span>';
                     if ( avail ) {
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
-                        html += makeCartBtn( dName );
+                        html += makeCartBtn( dName, d.listPrice || d.salePrice, d.productId );
                     } else {
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--no"><?php echo esc_js( __( 'No disponible', 'gano-child' ) ); ?></span>';
                     }
@@ -154,7 +155,7 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                         html += '<li class="gano-domain-item is-available">';
                         html += '<span class="gano-domain-item__name">' + escHtml( dName ) + '</span>';
                         html += '<span class="gano-domain-item__badge gano-domain-item__badge--ok"><?php echo esc_js( __( 'Disponible', 'gano-child' ) ); ?></span>';
-                        html += makeCartBtn( dName );
+                        html += makeCartBtn( dName, d.listPrice || d.salePrice, d.productId );
                         html += '</li>';
                     });
                 }
@@ -165,14 +166,15 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
                 // Vincular botones de carrito — POST al proxy PHP → redirect a GoDaddy
                 results.querySelectorAll('.gano-domain-item__cta[data-domain]').forEach( function(btn) {
                     btn.addEventListener('click', function() {
-                        var domain = btn.getAttribute('data-domain');
+                        var domain    = btn.getAttribute('data-domain');
+                        var productId = btn.getAttribute('data-pid') || '';
                         btn.disabled = true;
                         btn.textContent = '<?php echo esc_js( __( 'Abriendo…', 'gano-child' ) ); ?>';
 
                         fetch( CART_URL, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ domain: domain })
+                            body: JSON.stringify({ domain: domain, productId: productId })
                         })
                         .then( function(r) { return r.json(); } )
                         .then( function(data) {


### PR DESCRIPTION
Simplifica el proxy del carrito: en lugar de POST a GoDaddy (que requiere cookies de sesión), construye la URL de registro directamente. Instantáneo, sin timeout. También muestra el precio COP real de la API en cada botón.