### PR TITLE
fix(dominios): extraer SLD para búsqueda + mensaje de ayuda mejorado

### DIFF
--- a/wp-content/themes/gano-child/functions.php
+++ b/wp-content/themes/gano-child/functions.php
@@ -3346,8 +3346,21 @@ function gano_domain_search_proxy_callback( WP_REST_Request $request ): WP_REST_
         $plid = 599667; // PLID Gano Digital hard-coded como último fallback
     }
 
-    $q         = trim( (string) $request->get_param( 'q' ) );
+    $q_raw     = strtolower( trim( (string) $request->get_param( 'q' ) ) );
     $page_size = min( (int) $request->get_param( 'pageSize' ), 10 );
+
+    // Si el usuario escribe "basoccer.club", enviar solo "basoccer" a la API.
+    // GoDaddy sugiere los TLDs disponibles — el TLD específico puede no estar
+    // en el catálogo del Reseller y daría cero resultados.
+    $q = $q_raw;
+    if ( substr_count( $q, '.' ) >= 1 ) {
+        // Extraer solo el SLD (parte antes del primer punto)
+        $parts = explode( '.', $q );
+        $sld   = $parts[0];
+        if ( strlen( $sld ) >= 2 ) {
+            $q = $sld;
+        }
+    }
 
     $api_url = add_query_arg(
         array(

--- a/wp-content/themes/gano-child/templates/page-dominios.php
+++ b/wp-content/themes/gano-child/templates/page-dominios.php
@@ -113,12 +113,13 @@ $proxy_url = rest_url( 'gano/v1/domains/search' );
             }
 
             function renderResults( data ) {
-                if ( ! data || ( ! data.exactMatchDomain && ! data.suggestedDomains ) ) {
-                    results.innerHTML = '<p class="gano-domain-error"><?php echo esc_js( __( 'No se encontraron resultados. Intenta con otro nombre.', 'gano-child' ) ); ?></p>';
+                if ( ! data || ( ! data.exactMatchDomain && ( ! data.suggestedDomains || ! data.suggestedDomains.length ) ) ) {
+                    results.innerHTML = '<p class="gano-domain-error"><?php echo esc_js( __( 'No se encontraron resultados. Intenta solo con el nombre sin extensión (ej: "miempresa" en lugar de "miempresa.com").', 'gano-child' ) ); ?></p>';
                     return;
                 }
 
                 var html = '<ul class="gano-domain-list">';
+                var itemCount = 0;
 
                 // Resultado exacto primero
                 // GoDaddy API usa el campo 'domain' (no 'fqdn')


### PR DESCRIPTION
Cuando el usuario escribe con TLD (basoccer.club), el proxy extrae solo 'basoccer' antes de llamar a la API. Evita cero resultados cuando el TLD no está en el catálogo Reseller.