### PR TITLE
security: redact revoked DeepSeek API key (#352)

### DIFF
--- a/DEEPSEEK_API_RESEARCH_REPORT.md
+++ b/DEEPSEEK_API_RESEARCH_REPORT.md
@@ -38,7 +38,7 @@ DeepSeek is a Chinese AI company offering high-performance language models via a
 ```
 Header: Authorization: Bearer {API_KEY}
 Format: API key obtained from https://platform.deepseek.com/api_keys
-Example: Authorization: Bearer sk-0302b562eb404d1097c13d70dc64bb87
+Example: Authorization: Bearer sk-REVOKED-see-issue-352
 ```
 
 ### Required Headers
@@ -295,7 +295,7 @@ from openai import OpenAI
 
 # Minimal setup
 client = OpenAI(
-    api_key="sk-0302b562eb404d1097c13d70dc64bb87",
+    api_key="sk-REVOKED-see-issue-352",
     base_url="https://api.deepseek.com/v1"
 )
 
@@ -314,7 +314,7 @@ print(response.choices[0].message.content)
 import OpenAI from "openai";
 
 const client = new OpenAI({
-  apiKey: "sk-0302b562eb404d1097c13d70dc64bb87",
+  apiKey: "sk-REVOKED-see-issue-352",
   baseURL: "https://api.deepseek.com/v1",
 });
 
@@ -488,7 +488,7 @@ One 10K-token request:
 ### Action Items
 
 1. **Immediate (Week 1):**
-   - [ ] Verify API key works: `sk-0302b562eb404d1097c13d70dc64bb87`
+   - [ ] Verify API key works: `sk-REVOKED-see-issue-352`
    - [ ] Create Python wrapper around OpenAI client with Deepseek endpoint
    - [ ] Add Deepseek-V4-Pro as secondary fallback (after Opus rate limit)
    - [ ] Implement exponential backoff for HTTP 429 responses
@@ -570,7 +570,7 @@ Quality Tradeoff:
 # Test your API key
 curl -X POST https://api.deepseek.com/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-0302b562eb404d1097c13d70dc64bb87" \
+  -H "Authorization: Bearer sk-REVOKED-see-issue-352" \
   -d '{
     "model": "deepseek-v4-flash",
     "messages": [{"role": "user", "content": "Hello"}],

--- a/DEEPSEEK_EXECUTIVE_SUMMARY.md
+++ b/DEEPSEEK_EXECUTIVE_SUMMARY.md
@@ -86,7 +86,7 @@ With 100% V4-Flash (high-volume tier):
 ### API Details
 ```
 Endpoint: https://api.deepseek.com/v1/chat/completions
-Auth: Bearer token (sk-0302b562eb404d1097c13d70dc64bb87)
+Auth: Bearer token (sk-REVOKED-see-issue-352)
 Format: 100% OpenAI-compatible
 Models: deepseek-v4-pro | deepseek-v4-flash
 Rate Limits: Dynamic (no published RPM/TPM caps)
@@ -100,7 +100,7 @@ from openai import OpenAI
 
 # That's literally it
 deepseek = OpenAI(
-    api_key="sk-0302b562eb404d1097c13d70dc64bb87",
+    api_key="sk-REVOKED-see-issue-352",
     base_url="https://api.deepseek.com/v1"
 )
 

--- a/DEEPSEEK_FINAL_SUMMARY.txt
+++ b/DEEPSEEK_FINAL_SUMMARY.txt
@@ -147,7 +147,7 @@ Week 4+: Sustain (Ongoing)
 
 API Details
   Base URL: https://api.deepseek.com/v1
-  Auth: Bearer token (sk-0302b562eb404d1097c13d70dc64bb87)
+  Auth: Bearer token (sk-REVOKED-see-issue-352)
   Format: 100% OpenAI-compatible
   Rate Limits: Dynamic (no published caps)
   Context: 1M tokens
@@ -182,7 +182,7 @@ Python 3 Lines Setup
 from openai import OpenAI
 
 deepseek = OpenAI(
-    api_key="sk-0302b562eb404d1097c13d70dc64bb87",
+    api_key="sk-REVOKED-see-issue-352",
     base_url="https://api.deepseek.com/v1"
 )
 
@@ -201,7 +201,7 @@ Node.js Setup
 import OpenAI from "openai";
 
 const deepseek = new OpenAI({
-  apiKey: "sk-0302b562eb404d1097c13d70dc64bb87",
+  apiKey: "sk-REVOKED-see-issue-352",
   baseURL: "https://api.deepseek.com/v1",
 });
 

--- a/DEEPSEEK_QUICK_REFERENCE.txt
+++ b/DEEPSEEK_QUICK_REFERENCE.txt
@@ -62,7 +62,7 @@ Endpoints
 Authentication
   Header:                 Authorization: Bearer {API_KEY}
   Format:                 Bearer token (from platform.deepseek.com)
-  Example key:            sk-0302b562eb404d1097c13d70dc64bb87
+  Example key:            sk-REVOKED-see-issue-352
 
 Models
   Primary:                deepseek-v4-pro (1.6T/49B, quality-focused)
@@ -132,7 +132,7 @@ Python (Drop-in Replacement)
 from openai import OpenAI
 
 deepseek = OpenAI(
-    api_key="sk-0302b562eb404d1097c13d70dc64bb87",
+    api_key="sk-REVOKED-see-issue-352",
     base_url="https://api.deepseek.com/v1"
 )
 
@@ -146,7 +146,7 @@ Node.js (Drop-in Replacement)
 import OpenAI from "openai";
 
 const deepseek = new OpenAI({
-  apiKey: "sk-0302b562eb404d1097c13d70dc64bb87",
+  apiKey: "sk-REVOKED-see-issue-352",
   baseURL: "https://api.deepseek.com/v1",
 });
 


### PR DESCRIPTION
Resuelve #352.

## Qué
Se redacta la API key de DeepSeek (`sk-0302…`) que estaba commiteada en 4 archivos, reemplazándola por el placeholder `sk-REVOKED-see-issue-352`. Se preserva el resto del contenido de investigación.

Archivos:
- `DEEPSEEK_FINAL_SUMMARY.txt`
- `DEEPSEEK_API_RESEARCH_REPORT.md`
- `DEEPSEEK_QUICK_REFERENCE.txt`
- `DEEPSEEK_EXECUTIVE_SUMMARY.md`

(El reporte original #352 solo mencionaba 1 archivo; el escaneo encontró la misma key en los 4.)

## Estado de seguridad
- ✅ **La key ya fue revocada** por el dueño en platform.deepseek.com — está muerta.
- ℹ️ La key sigue en el **historial de git** (commit d97a8f8). Como ya está revocada y el repo está en desarrollo activo (PRs/ramas abiertas), **no se reescribió el historial** para evitar romper PRs y forks. Si se requiere purgar el historial igualmente, hacer `git filter-repo --replace-text` + force-push en una ventana coordinada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)